### PR TITLE
feat(desktop): 增加 CI 私有化打包与品牌注入，且不覆盖 SaaS 分发

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,18 @@ spec:
         - enterprise
         - oss
       description: '构建版本类型，oss=社区版，enterprise=企业版'
+    desktop_deployment_mode:
+      default: public
+      options:
+        - public
+        - private
+      description: '桌面端 public=SaaS 安装包，private=私有化安装包'
+    desktop_deploy_mode:
+      default: ""
+      description: '私有化客户标识，对应 frontend/private/logo/{mode}/ 与 COS private/{mode}/；可空'
+    desktop_app_name:
+      default: ""
+      description: '可选桌面品牌名，留空则仍为 Lework'
 ---
 
 stages:
@@ -41,6 +53,9 @@ variables:
   ENV: "$[[ inputs.environment ]]"
   APP: "$[[ inputs.app ]]"
   UPDATE_WORKER_IMAGE: "$[[ inputs.update_worker_image ]]"
+  DESKTOP_DEPLOYMENT_MODE: "$[[ inputs.desktop_deployment_mode ]]"
+  LEROS_DEPLOY_MODE: "$[[ inputs.desktop_deploy_mode ]]"
+  LEROS_DEPLOY_APP_NAME: "$[[ inputs.desktop_app_name ]]"
   K3S_NAMESPACE_TEST: "insmtx-test"
   K3S_SERVER_DEPLOYMENT: "leros"
   K3S_SERVER_CONTAINER: "leros"
@@ -469,6 +484,13 @@ deploy:
       prefix="${DESKTOP_COS_PREFIX#/}"
       prefix="${prefix%/}"
       printf '%s\n' "$version" > "$CI_PROJECT_DIR/LATEST.txt"
+      deployment_mode="${DESKTOP_DEPLOYMENT_MODE:-public}"
+      name_suffix=""
+      private_script_infix=""
+      if [ "$deployment_mode" = "private" ]; then
+        name_suffix="-private"
+        private_script_infix=":private"
+      fi
 
       upload_dir() {
         local local_dir="$1"
@@ -499,54 +521,55 @@ deploy:
 
       case "$DESKTOP_TARGET" in
         mac-arm64)
-          build_script="dist:desktop:mac:arm64"
+          build_script="dist:desktop${private_script_infix}:mac:arm64"
           release_dir="desktop-release/mac-arm64"
           cos_target_dir="darwin/arm64"
           latest_file="latest-mac.yml"
-          root_installer="Lework-${version}-mac-arm64.dmg"
+          root_installer="Lework-${version}-mac-arm64${name_suffix}.dmg"
           build_with_signing="true"
           payload_files="
-            Lework-${version}-mac-arm64.dmg
-            Lework-${version}-mac-arm64.zip
-            Lework-${version}-mac-arm64.dmg.blockmap
-            Lework-${version}-mac-arm64.zip.blockmap
+            Lework-${version}-mac-arm64${name_suffix}.dmg
+            Lework-${version}-mac-arm64${name_suffix}.zip
+            Lework-${version}-mac-arm64${name_suffix}.dmg.blockmap
+            Lework-${version}-mac-arm64${name_suffix}.zip.blockmap
           "
           ;;
         mac-x64)
-          build_script="dist:desktop:mac:x64"
+          build_script="dist:desktop${private_script_infix}:mac:x64"
           release_dir="desktop-release/mac-x64"
           cos_target_dir="darwin/x64"
           latest_file="latest-mac.yml"
-          root_installer="Lework-${version}-mac-x64.dmg"
+          root_installer="Lework-${version}-mac-x64${name_suffix}.dmg"
           build_with_signing="true"
           payload_files="
-            Lework-${version}-mac-x64.dmg
-            Lework-${version}-mac-x64.zip
-            Lework-${version}-mac-x64.dmg.blockmap
-            Lework-${version}-mac-x64.zip.blockmap
+            Lework-${version}-mac-x64${name_suffix}.dmg
+            Lework-${version}-mac-x64${name_suffix}.zip
+            Lework-${version}-mac-x64${name_suffix}.dmg.blockmap
+            Lework-${version}-mac-x64${name_suffix}.zip.blockmap
           "
           ;;
         win-x64)
-          build_script="dist:desktop:win:x64"
+          build_script="dist:desktop${private_script_infix}:win:x64"
           release_dir="desktop-release/win-x64"
           cos_target_dir="win32/x64"
           latest_file="latest.yml"
-          root_installer="Lework-${version}-win-x64.exe"
+          root_installer="Lework-${version}-win-x64${name_suffix}.exe"
           build_with_signing="false"
           payload_files="
-            Lework-${version}-win-x64.exe
-            Lework-${version}-win-x64.exe.blockmap
+            Lework-${version}-win-x64${name_suffix}.exe
+            Lework-${version}-win-x64${name_suffix}.exe.blockmap
           "
           ;;
         linux-x64)
-          build_script="dist:desktop:linux:x64"
+          build_script="dist:desktop${private_script_infix}:linux:x64"
           release_dir="desktop-release/linux-x64"
           cos_target_dir="linux/x64"
           latest_file="latest-linux.yml"
-          root_installer="Lework-${version}-linux-amd64.deb"
+          root_installer="Lework-${version}-linux-amd64${name_suffix}.deb"
+          linux_alt_installer="Lework-${version}-linux-x64${name_suffix}.deb"
           build_with_signing="false"
           payload_files="
-            Lework-${version}-linux-amd64.deb
+            Lework-${version}-linux-amd64${name_suffix}.deb
           "
           ;;
         *)
@@ -599,15 +622,36 @@ deploy:
         trap - EXIT
       fi
 
+      if [ "$DESKTOP_TARGET" = "linux-x64" ] && [ ! -f "frontend/apps/desktop/dist/${root_installer}" ] && [ -n "${linux_alt_installer:-}" ] && [ -f "frontend/apps/desktop/dist/${linux_alt_installer}" ]; then
+        cp "frontend/apps/desktop/dist/${linux_alt_installer}" "frontend/apps/desktop/dist/${root_installer}"
+      fi
+
       mkdir -p "$release_dir"
       for payload_file in $payload_files; do
         cp "frontend/apps/desktop/dist/${payload_file}" "$release_dir/" 2>/dev/null || true
       done
       cp "frontend/apps/desktop/dist/${latest_file}" "$release_dir/" 2>/dev/null || true
 
-      upload_dir "$release_dir" "$cos_target_dir"
-      upload_file "${release_dir}/${root_installer}" "$root_prefix"
-      upload_file "LATEST.txt" "$root_prefix"
+      if [ "$deployment_mode" = "private" ]; then
+        deploy_mode="${LEROS_DEPLOY_MODE}"
+        if [ -z "$deploy_mode" ]; then
+          echo "Private desktop build without LEROS_DEPLOY_MODE; skip COS upload to keep SaaS packages untouched"
+        elif ! printf '%s' "$deploy_mode" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'; then
+          echo "Invalid LEROS_DEPLOY_MODE: $deploy_mode"
+          exit 1
+        else
+          private_prefix="${root_prefix}/private/${deploy_mode}"
+          upload_file "${release_dir}/${root_installer}" "$private_prefix"
+          upload_file "LATEST.txt" "$private_prefix"
+          cos_host="https://${COS_BUCKET}.cos.${COS_REGION}.myqcloud.com"
+          echo "Private installer URL: ${cos_host}/${private_prefix}/${root_installer}"
+          echo "Website hidden download: /download?edition=private&mode=${deploy_mode}"
+        fi
+      else
+        upload_dir "$release_dir" "$cos_target_dir"
+        upload_file "${release_dir}/${root_installer}" "$root_prefix"
+        upload_file "LATEST.txt" "$root_prefix"
+      fi
 
 # ============================================================================
 # 桌面端打包 - 平台 template / job
@@ -700,7 +744,7 @@ desktop-update-k3s-client-version:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
-    - if: '$APP == "desktop" && $ENV != "image"'
+    - if: '$APP == "desktop" && $ENV != "image" && $DESKTOP_DEPLOYMENT_MODE != "private"'
       when: on_success
     - when: never
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,8 @@ spec:
         - test
         - prod
         - image
-      description: 发布的环境选择，image为仅构建镜像
+        - private
+      description: 发布的环境选择，image为仅构建镜像，private为桌面端私有化打包
     app:
       default: leros
       options:
@@ -27,12 +28,6 @@ spec:
         - enterprise
         - oss
       description: '构建版本类型，oss=社区版，enterprise=企业版'
-    desktop_deployment_mode:
-      default: public
-      options:
-        - public
-        - private
-      description: '桌面端 public=SaaS 安装包，private=私有化安装包'
     desktop_deploy_mode:
       default: ""
       description: '私有化客户标识，对应 frontend/private/logo/{mode}/ 与 COS private/{mode}/；可空'
@@ -53,7 +48,6 @@ variables:
   ENV: "$[[ inputs.environment ]]"
   APP: "$[[ inputs.app ]]"
   UPDATE_WORKER_IMAGE: "$[[ inputs.update_worker_image ]]"
-  DESKTOP_DEPLOYMENT_MODE: "$[[ inputs.desktop_deployment_mode ]]"
   LEROS_DEPLOY_MODE: "$[[ inputs.desktop_deploy_mode ]]"
   LEROS_DEPLOY_APP_NAME: "$[[ inputs.desktop_app_name ]]"
   K3S_NAMESPACE_TEST: "insmtx-test"
@@ -174,6 +168,8 @@ deploy:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$APP == "desktop"'
+      when: never
+    - if: '$ENV == "private"'
       when: never
     - if: '$ENV != "image"'
       when: on_success
@@ -484,7 +480,10 @@ deploy:
       prefix="${DESKTOP_COS_PREFIX#/}"
       prefix="${prefix%/}"
       printf '%s\n' "$version" > "$CI_PROJECT_DIR/LATEST.txt"
-      deployment_mode="${DESKTOP_DEPLOYMENT_MODE:-public}"
+      deployment_mode="public"
+      if [ "$ENV" = "private" ]; then
+        deployment_mode="private"
+      fi
       name_suffix=""
       private_script_infix=""
       if [ "$deployment_mode" = "private" ]; then
@@ -744,7 +743,7 @@ desktop-update-k3s-client-version:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
-    - if: '$APP == "desktop" && $ENV != "image" && $DESKTOP_DEPLOYMENT_MODE != "private"'
+    - if: '$APP == "desktop" && $ENV != "image" && $ENV != "private"'
       when: on_success
     - when: never
   needs:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -28,6 +28,12 @@ Thumbs.db
 .env.local
 .env.*.local
 
+# 客户私有化 Logo，不进开源仓
+private/logo/*/
+
+# 打包时从 private/logo 拷入的品牌资源
+apps/desktop/src/renderer/public/brand/
+
 # Logs
 *.log
 npm-debug.log*

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -195,6 +195,22 @@ pnpm dist:desktop:private
 pnpm dist:desktop:private:dir
 ```
 
+私有化品牌注入（可选，不设则仍为 Lework）：
+
+```bash
+# 只设客户标识。若 frontend/private/logo/{mode}/ 不存在，沿用官方 Logo
+LEROS_DEPLOY_MODE=acme pnpm dist:desktop:private:win:x64
+
+# 目录内放好 logo.svg 或 logo.png 后，打包进客户 Logo
+# frontend/private/logo/acme/logo.svg
+LEROS_DEPLOY_MODE=acme pnpm dist:desktop:private:win:x64
+
+# 同时替换界面品牌名
+LEROS_DEPLOY_MODE=acme LEROS_DEPLOY_APP_NAME=AcmeAI pnpm dist:desktop:private:win:x64
+```
+
+约定见 [private/README.md](private/README.md)。CI 私有化包上传到 COS `application/private/{mode}/`，官网隐藏入口为 `/download?edition=private&mode={mode}`；SaaS Linux 为 `/download?platform=linux`。
+
 产物输出到 `apps/desktop/dist/`。本地 `dist:*` 命令固定使用 `--publish never`，只生成安装包，不会上传 Release。
 `pnpm dist:desktop` 用于快速验证当前系统包：macOS 默认只生成 ZIP，避免部分本地/沙箱环境无法调用 `hdiutil` 创建 DMG；Windows 默认生成 NSIS 安装包；Linux 默认生成 AppImage 和 `.deb`。`pnpm dist:desktop:dir` / `pnpm dist:desktop:private:dir` 只生成未打包应用目录，适合最快速验证 Electron/Vite 构建和应用启动；后者会注入私有化部署标记。正式 macOS Release 请使用 `dist:desktop:mac:arm64` / `dist:desktop:mac:x64` 或 tag workflow。
 

--- a/frontend/apps/desktop/electron.vite.config.ts
+++ b/frontend/apps/desktop/electron.vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
 		plugins: [externalizeDepsPlugin()],
 	},
 	renderer: {
+		publicDir: resolve("src/renderer/public"),
 		server: {
 			port: Number(process.env.DESKTOP_RENDERER_PORT) || 5175,
 			strictPort: true,

--- a/frontend/apps/desktop/package.json
+++ b/frontend/apps/desktop/package.json
@@ -15,7 +15,7 @@
     "dev": "electron-vite dev",
     "compile": "electron-vite build",
     "build": "pnpm run compile",
-    "icons": "node scripts/generate-icons.mjs",
+    "icons": "node scripts/inject-deploy-config.mjs && node scripts/generate-icons.mjs",
     "dist": "node scripts/dist-local.mjs",
     "dist:private": "node scripts/dist-private.mjs",
     "dist:private:dir": "node scripts/dist-private-target.mjs --dir",

--- a/frontend/apps/desktop/scripts/generate-icons.mjs
+++ b/frontend/apps/desktop/scripts/generate-icons.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -6,8 +7,16 @@ import sharp from 'sharp'
 
 const currentDir = dirname(fileURLToPath(import.meta.url))
 const appDir = resolve(currentDir, '..')
-const sourceLogo = resolve(appDir, '../../packages/app-ui/assets/logo.svg')
+const defaultLogo = resolve(appDir, '../../packages/app-ui/assets/logo.svg')
 const sourceTrayLogo = resolve(appDir, '../../packages/app-ui/assets/logo-white.svg')
+const injectedLogoSvg = join(appDir, 'src/renderer/public/brand/logo.svg')
+const injectedLogoPng = join(appDir, 'src/renderer/public/brand/logo.png')
+const sourceLogo = existsSync(injectedLogoSvg)
+  ? injectedLogoSvg
+  : existsSync(injectedLogoPng)
+    ? injectedLogoPng
+    : defaultLogo
+const sourceTrayLogoResolved = sourceLogo === defaultLogo ? sourceTrayLogo : sourceLogo
 const resourcesDir = join(appDir, 'resources')
 
 const iconPngPath = join(resourcesDir, 'icon.png')
@@ -25,7 +34,7 @@ await mkdir(resourcesDir, { recursive: true })
 await mkdir(linuxIconsDir, { recursive: true })
 await sharp(await renderIcon(1024)).toFile(iconPngPath)
 await sharp(await renderMacIcon(1024)).toFile(iconMacPngPath)
-await sharp(await renderIcon(128, { source: sourceTrayLogo, logoScale: 0.9 })).toFile(trayIconPngPath)
+await sharp(await renderIcon(128, { source: sourceTrayLogoResolved, logoScale: 0.9 })).toFile(trayIconPngPath)
 
 // 中文注释：银河麒麟/UKUI 等桌面只会从标准 hicolor 尺寸目录中查找任务栏图标，
 // 不能只依赖 1024x1024 图标，因此为 Linux 安装包生成完整的 freedesktop 图标集。

--- a/frontend/apps/desktop/scripts/inject-deploy-config.mjs
+++ b/frontend/apps/desktop/scripts/inject-deploy-config.mjs
@@ -1,0 +1,90 @@
+import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { dirname, extname, join, resolve } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+const currentDir = dirname(fileURLToPath(import.meta.url))
+const appDir = resolve(currentDir, "..")
+const frontendRoot = resolve(appDir, "../..")
+const rendererPublicDir = join(appDir, "src/renderer/public")
+
+const LOGO_CANDIDATES = ["logo.svg", "logo.png"]
+const MODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
+
+export function sanitizeDeployMode (value) {
+	const mode = typeof value === "string" ? value.trim() : ""
+	if (!mode) return ""
+	if (mode.includes("..") || mode.includes("/") || mode.includes("\\") || !MODE_PATTERN.test(mode)) {
+		throw new Error(`Invalid LEROS_DEPLOY_MODE: ${value}`)
+	}
+	return mode
+}
+
+export function renderDeployConfigScript (config) {
+	return `window.__DEPLOYCONFIG = ${JSON.stringify(config, null, 2)};\n`
+}
+
+function pickLogoFile (modeDir) {
+	for (const fileName of LOGO_CANDIDATES) {
+		const filePath = join(modeDir, fileName)
+		if (existsSync(filePath)) return filePath
+	}
+	return null
+}
+
+export async function injectDeployConfig ({
+	mode = process.env.LEROS_DEPLOY_MODE,
+	appName = process.env.LEROS_DEPLOY_APP_NAME,
+	deploymentMode = process.env.VITE_LEROS_DEPLOYMENT_MODE,
+	frontendRoot: frontendRootArg = frontendRoot,
+	rendererPublicDir: rendererPublicDirArg = rendererPublicDir,
+} = {}) {
+	const sanitizedMode = sanitizeDeployMode(mode)
+	const trimmedAppName = typeof appName === "string" ? appName.trim() : ""
+	const version = deploymentMode === "private" ? "private" : "public"
+	const resolvedPublicDir = rendererPublicDirArg
+	const resolvedBrandDir = join(resolvedPublicDir, "brand")
+	const resolvedConfigPath = join(resolvedPublicDir, "config.js")
+	const resolvedLogoRoot = join(frontendRootArg, "private/logo")
+
+	await mkdir(resolvedBrandDir, { recursive: true })
+
+	let logoPublicPath = ""
+	if (sanitizedMode) {
+		const modeDir = join(resolvedLogoRoot, sanitizedMode)
+		if (existsSync(modeDir)) {
+			const logoFile = pickLogoFile(modeDir)
+			if (!logoFile) {
+				const entries = await readdir(modeDir)
+				throw new Error(
+					`frontend/private/logo/${sanitizedMode}/ exists but has no logo.svg or logo.png (${entries.join(", ") || "empty"})`,
+				)
+			}
+			const outputName = `logo${extname(logoFile).toLowerCase()}`
+			await copyFile(logoFile, join(resolvedBrandDir, outputName))
+			logoPublicPath = `./brand/${outputName}`
+			console.log(`[inject-deploy-config] using private logo ${logoFile}`)
+		} else {
+			console.log(
+				`[inject-deploy-config] LEROS_DEPLOY_MODE=${sanitizedMode} but logo directory is missing; keep default Lework logo`,
+			)
+		}
+	}
+
+	const config = {
+		version,
+		mode: sanitizedMode,
+		appName: trimmedAppName || "Lework",
+		logo: logoPublicPath,
+	}
+
+	await writeFile(resolvedConfigPath, renderDeployConfigScript(config), "utf8")
+	console.log(`[inject-deploy-config] wrote ${resolvedConfigPath}`)
+	return config
+}
+
+const isDirectRun = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isDirectRun) {
+	await injectDeployConfig()
+}

--- a/frontend/apps/desktop/src/main/__tests__/inject-deploy-config.test.ts
+++ b/frontend/apps/desktop/src/main/__tests__/inject-deploy-config.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { injectDeployConfig, sanitizeDeployMode } from "../../../scripts/inject-deploy-config.mjs";
+
+describe("inject deploy config", () => {
+	const dirs: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+		vi.unstubAllEnvs();
+	});
+
+	it("rejects unsafe mode values", () => {
+		expect(() => sanitizeDeployMode("../x")).toThrow(/Invalid LEROS_DEPLOY_MODE/);
+		expect(() => sanitizeDeployMode("acme/h3c")).toThrow(/Invalid LEROS_DEPLOY_MODE/);
+		expect(sanitizeDeployMode("acme")).toBe("acme");
+	});
+
+	it("keeps default logo when mode directory is missing", async () => {
+		const root = await mkdtemp(join(tmpdir(), "leros-deploy-"));
+		dirs.push(root);
+		const result = await injectDeployConfig({
+			mode: "acme",
+			appName: "",
+			deploymentMode: "private",
+			frontendRoot: root,
+			rendererPublicDir: join(root, "public"),
+		});
+		expect(result.logo).toBe("");
+		expect(result.appName).toBe("Lework");
+		expect(result.mode).toBe("acme");
+		expect(result.version).toBe("private");
+	});
+
+	it("copies logo when the mode directory contains a logo file", async () => {
+		const root = await mkdtemp(join(tmpdir(), "leros-deploy-"));
+		dirs.push(root);
+		const modeDir = join(root, "private/logo/acme");
+		await mkdir(modeDir, { recursive: true });
+		await writeFile(join(modeDir, "logo.svg"), "<svg></svg>");
+		const publicDir = join(root, "public");
+		const result = await injectDeployConfig({
+			mode: "acme",
+			appName: "AcmeAI",
+			deploymentMode: "private",
+			frontendRoot: root,
+			rendererPublicDir: publicDir,
+		});
+		expect(result.logo).toBe("./brand/logo.svg");
+		expect(result.appName).toBe("AcmeAI");
+		const packed = await readFile(join(publicDir, "brand/logo.svg"), "utf8");
+		expect(packed).toContain("<svg");
+	});
+
+	it("fails when the mode directory exists but has no logo file", async () => {
+		const root = await mkdtemp(join(tmpdir(), "leros-deploy-"));
+		dirs.push(root);
+		await mkdir(join(root, "private/logo/acme"), { recursive: true });
+		await expect(
+			injectDeployConfig({
+				mode: "acme",
+				deploymentMode: "private",
+				frontendRoot: root,
+				rendererPublicDir: join(root, "public"),
+			}),
+		).rejects.toThrow(/exists but has no logo.svg or logo.png/);
+	});
+});

--- a/frontend/apps/desktop/src/main/__tests__/private-deployment-build.test.ts
+++ b/frontend/apps/desktop/src/main/__tests__/private-deployment-build.test.ts
@@ -58,14 +58,15 @@ describe("private deployment build marker", () => {
 	it("keeps private GitLab packages off the SaaS COS prefix", () => {
 		const gitlabCi = readFileSync(resolve(desktopRoot, "../../../.gitlab-ci.yml"), "utf8");
 
-		expect(gitlabCi).toContain("desktop_deployment_mode");
+		expect(gitlabCi).toContain("- private");
+		expect(gitlabCi).toContain('if [ "$ENV" = "private" ]');
 		expect(gitlabCi).toContain("dist:desktop${private_script_infix}");
 		expect(gitlabCi).toContain('name_suffix="-private"');
 		expect(gitlabCi).toContain("${root_prefix}/private/${deploy_mode}");
 		expect(gitlabCi).toContain("skip COS upload to keep SaaS packages untouched");
 		expect(gitlabCi).toContain("Invalid LEROS_DEPLOY_MODE");
 		expect(gitlabCi).toContain("/download?edition=private&mode=${deploy_mode}");
-		expect(gitlabCi).toContain('$DESKTOP_DEPLOYMENT_MODE != "private"');
+		expect(gitlabCi).toContain('$ENV != "private"');
 	});
 
 	it("keeps renderer workspace packages out of production dependencies", () => {

--- a/frontend/apps/desktop/src/main/__tests__/private-deployment-build.test.ts
+++ b/frontend/apps/desktop/src/main/__tests__/private-deployment-build.test.ts
@@ -8,7 +8,7 @@ describe("private deployment build marker", () => {
 	it("injects the deployment mode into the renderer build", () => {
 		const viteConfig = readFileSync(resolve(desktopRoot, "electron.vite.config.ts"), "utf8");
 
-		expect(viteConfig).toContain('"import.meta.env.VITE_LEROS_DEPLOYMENT_MODE"');
+		expect(viteConfig).toContain("publicDir: resolve(\"src/renderer/public\")");
 		expect(viteConfig).toContain('process.env.VITE_LEROS_DEPLOYMENT_MODE ?? "public"');
 	});
 
@@ -51,7 +51,21 @@ describe("private deployment build marker", () => {
 		expect(privateTargetScript).toContain('VITE_LEROS_DEPLOYMENT_MODE = "private"');
 		expect(privateTargetScript).toContain("runDesktopDist(builderArgs)");
 		expect(distRunScript).toContain("-linux-${arch}-private.${ext}");
+		expect(desktopPackage.scripts?.icons).toContain("inject-deploy-config.mjs");
 		expect(desktopPackage.scripts?.["dist:linux:arm64"]).toContain("AppImage:arm64 deb:arm64");
+	});
+
+	it("keeps private GitLab packages off the SaaS COS prefix", () => {
+		const gitlabCi = readFileSync(resolve(desktopRoot, "../../../.gitlab-ci.yml"), "utf8");
+
+		expect(gitlabCi).toContain("desktop_deployment_mode");
+		expect(gitlabCi).toContain("dist:desktop${private_script_infix}");
+		expect(gitlabCi).toContain('name_suffix="-private"');
+		expect(gitlabCi).toContain("${root_prefix}/private/${deploy_mode}");
+		expect(gitlabCi).toContain("skip COS upload to keep SaaS packages untouched");
+		expect(gitlabCi).toContain("Invalid LEROS_DEPLOY_MODE");
+		expect(gitlabCi).toContain("/download?edition=private&mode=${deploy_mode}");
+		expect(gitlabCi).toContain('$DESKTOP_DEPLOYMENT_MODE != "private"');
 	});
 
 	it("keeps renderer workspace packages out of production dependencies", () => {

--- a/frontend/apps/desktop/src/renderer/index.html
+++ b/frontend/apps/desktop/src/renderer/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lework</title>
+    <script src="./config.js"></script>
   </head>
   <body class="h-full overflow-hidden antialiased font-sans">
     <div id="root" class="h-full"></div>

--- a/frontend/apps/desktop/src/renderer/public/config.js
+++ b/frontend/apps/desktop/src/renderer/public/config.js
@@ -1,0 +1,6 @@
+window.__DEPLOYCONFIG = {
+	version: "public",
+	mode: "",
+	appName: "Lework",
+	logo: "",
+};

--- a/frontend/apps/desktop/src/renderer/src/env.d.ts
+++ b/frontend/apps/desktop/src/renderer/src/env.d.ts
@@ -5,3 +5,12 @@ interface ImportMetaEnv {
 	readonly VITE_LEROS_APP_VERSION?: string;
 	readonly VITE_LEROS_DEPLOYMENT_MODE?: "public" | "private";
 }
+
+interface Window {
+	__DEPLOYCONFIG?: {
+		version?: "public" | "private";
+		mode?: string;
+		appName?: string;
+		logo?: string;
+	};
+}

--- a/frontend/packages/app-ui/components/private-deployment/useBrandIdentity.ts
+++ b/frontend/packages/app-ui/components/private-deployment/useBrandIdentity.ts
@@ -21,5 +21,9 @@ export function useBrandIdentity() {
 		};
 	}, []);
 
+	useEffect(() => {
+		document.title = name;
+	}, [name]);
+
 	return { logo, name };
 }

--- a/frontend/packages/store/api/branding.test.ts
+++ b/frontend/packages/store/api/branding.test.ts
@@ -18,6 +18,7 @@ describe("branding storage", () => {
 		window.localStorage.removeItem(BRANDING_SETTINGS_ENABLED_STORAGE_KEY);
 		window.localStorage.removeItem(BRAND_LOGO_STORAGE_KEY);
 		window.localStorage.removeItem(BRAND_NAME_STORAGE_KEY);
+		delete window.__DEPLOYCONFIG;
 	});
 
 	it("treats branding settings as disabled until the enable key exists", () => {
@@ -37,11 +38,30 @@ describe("branding storage", () => {
 	it("falls back to default brand name when unset or cleared", () => {
 		expect(readBrandName()).toBe(DEFAULT_BRAND_NAME);
 		expect(readCustomBrandName()).toBeNull();
-		expect(saveBrandName("Acme")).toBe("Acme");
-		expect(readBrandName()).toBe("Acme");
-		expect(readCustomBrandName()).toBe("Acme");
+		window.__DEPLOYCONFIG = { appName: "AcmeAI", logo: "./brand/logo.svg" };
+		expect(readBrandName()).toBe("AcmeAI");
+		expect(readBrandLogo()).toBe("./brand/logo.svg");
+		expect(saveBrandName("LocalName")).toBe("LocalName");
+		expect(readBrandName()).toBe("LocalName");
+		expect(saveBrandLogo("file_logo_2")).toBe("file_logo_2");
+		expect(readBrandLogo()).toBe("file_logo_2");
 		expect(saveBrandName("   ")).toBe(DEFAULT_BRAND_NAME);
-		expect(readBrandName()).toBe(DEFAULT_BRAND_NAME);
+		expect(readBrandName()).toBe("AcmeAI");
 		expect(readCustomBrandName()).toBeNull();
+	});
+
+	it("uses packed deploy config when localStorage is empty", () => {
+		window.__DEPLOYCONFIG = { appName: "AcmeAI", logo: "./brand/logo.svg" };
+		expect(readBrandName()).toBe("AcmeAI");
+		expect(readBrandLogo()).toBe("./brand/logo.svg");
+		expect(readCustomBrandName()).toBeNull();
+	});
+
+	it("lets localStorage override packed deploy config", () => {
+		window.__DEPLOYCONFIG = { appName: "AcmeAI", logo: "./brand/logo.svg" };
+		expect(saveBrandName("LocalName")).toBe("LocalName");
+		expect(saveBrandLogo("file_logo_2")).toBe("file_logo_2");
+		expect(readBrandName()).toBe("LocalName");
+		expect(readBrandLogo()).toBe("file_logo_2");
 	});
 });

--- a/frontend/packages/store/api/branding.ts
+++ b/frontend/packages/store/api/branding.ts
@@ -1,3 +1,5 @@
+import { readDeployAppName, readDeployLogo } from "./deploy-config";
+
 /** 存在该 key 时，私有化系统设置展示品牌 Logo / 品牌名编辑区。 */
 export const BRANDING_SETTINGS_ENABLED_STORAGE_KEY = "leros-branding-settings-enabled";
 /** 自定义系统 Logo（通常为上传后的 file public_id）。 */
@@ -6,6 +8,7 @@ export const BRAND_LOGO_STORAGE_KEY = "leros-brand-logo";
 export const BRAND_NAME_STORAGE_KEY = "leros-brand-name";
 
 export const BRANDING_CHANGED_EVENT = "leros-branding-changed";
+
 export const DEFAULT_BRAND_NAME = "Lework";
 
 function notifyBrandingChanged() {
@@ -47,9 +50,9 @@ export function isBrandingSettingsEnabled(): boolean {
 	}
 }
 
-/** 读取自定义 Logo；未配置时返回 null，调用方应回退系统默认。 */
+/** 读取自定义 Logo；优先 localStorage，其次打包注入，未配置时返回 null。 */
 export function readBrandLogo(): string | null {
-	return readStorageItem(BRAND_LOGO_STORAGE_KEY);
+	return readStorageItem(BRAND_LOGO_STORAGE_KEY) ?? readDeployLogo();
 }
 
 export function saveBrandLogo(value: string): string {
@@ -65,9 +68,9 @@ export function clearBrandLogo() {
 	writeStorageItem(BRAND_LOGO_STORAGE_KEY, null);
 }
 
-/** 读取品牌名；未配置时返回默认 Lework。 */
+/** 读取品牌名；优先 localStorage，其次打包注入的 appName，否则默认 Lework。 */
 export function readBrandName(fallback: string = DEFAULT_BRAND_NAME): string {
-	return readStorageItem(BRAND_NAME_STORAGE_KEY) ?? fallback;
+	return readStorageItem(BRAND_NAME_STORAGE_KEY) ?? readDeployAppName() ?? fallback;
 }
 
 /** 读取已保存的自定义品牌名（不含默认回退），供设置页表单使用。 */

--- a/frontend/packages/store/api/deploy-config.test.ts
+++ b/frontend/packages/store/api/deploy-config.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_DEPLOY_CONFIG, readDeployAppName, readDeployConfig, readDeployLogo } from "./deploy-config";
+
+describe("deploy config", () => {
+	afterEach(() => {
+		delete window.__DEPLOYCONFIG;
+	});
+
+	it("returns SaaS defaults when window config is missing", () => {
+		expect(readDeployConfig()).toEqual(DEFAULT_DEPLOY_CONFIG);
+		expect(readDeployLogo()).toBeNull();
+		expect(readDeployAppName()).toBeNull();
+	});
+
+	it("reads packed private branding", () => {
+		window.__DEPLOYCONFIG = {
+			version: "private",
+			mode: "acme",
+			appName: "AcmeAI",
+			logo: "./brand/logo.svg",
+		};
+		expect(readDeployConfig()).toEqual({
+			version: "private",
+			mode: "acme",
+			appName: "AcmeAI",
+			logo: "./brand/logo.svg",
+		});
+		expect(readDeployLogo()).toBe("./brand/logo.svg");
+		expect(readDeployAppName()).toBe("AcmeAI");
+	});
+
+	it("does not treat default Lework appName as an injected brand", () => {
+		window.__DEPLOYCONFIG = { version: "private", mode: "acme", appName: "Lework", logo: "" };
+		expect(readDeployAppName()).toBeNull();
+		expect(readDeployLogo()).toBeNull();
+	});
+});

--- a/frontend/packages/store/api/deploy-config.ts
+++ b/frontend/packages/store/api/deploy-config.ts
@@ -1,0 +1,64 @@
+export type DeployVersion = "public" | "private";
+
+export type DeployConfig = {
+	version: DeployVersion;
+	mode: string;
+	appName: string;
+	logo: string;
+};
+
+export const DEFAULT_DEPLOY_APP_NAME = "Lework";
+
+export const DEFAULT_DEPLOY_CONFIG: DeployConfig = {
+	version: "public",
+	mode: "",
+	appName: DEFAULT_DEPLOY_APP_NAME,
+	logo: "",
+};
+
+declare global {
+	interface Window {
+		__DEPLOYCONFIG?: Partial<DeployConfig>;
+	}
+}
+
+function readWindowDeployConfig(): Partial<DeployConfig> | null {
+	if (typeof window === "undefined") return null;
+	const config = window.__DEPLOYCONFIG;
+	if (!config || typeof config !== "object") return null;
+	return config;
+}
+
+function trimString(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+/** 读取打包打入的部署配置；缺失字段回退到 SaaS 默认值。 */
+export function readDeployConfig(): DeployConfig {
+	const raw = readWindowDeployConfig();
+	if (!raw) return { ...DEFAULT_DEPLOY_CONFIG };
+
+	const version = raw.version === "private" ? "private" : "public";
+	const appName = trimString(raw.appName) || DEFAULT_DEPLOY_APP_NAME;
+
+	return {
+		version,
+		mode: trimString(raw.mode),
+		appName,
+		logo: trimString(raw.logo),
+	};
+}
+
+/** 打包注入的 Logo 路径；未注入时返回 null。 */
+export function readDeployLogo(): string | null {
+	const logo = readDeployConfig().logo;
+	return logo || null;
+}
+
+/** 打包注入的品牌名；未单独注入时返回 null，避免把默认 Lework 当成注入值。 */
+export function readDeployAppName(): string | null {
+	const raw = readWindowDeployConfig();
+	const appName = trimString(raw?.appName);
+	if (!appName || appName === DEFAULT_DEPLOY_APP_NAME) return null;
+	return appName;
+}

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -39,6 +39,14 @@ export {
 	saveBrandLogo,
 	saveBrandName,
 } from "./api/branding";
+export type { DeployConfig, DeployVersion } from "./api/deploy-config";
+export {
+	DEFAULT_DEPLOY_APP_NAME,
+	DEFAULT_DEPLOY_CONFIG,
+	readDeployAppName,
+	readDeployConfig,
+	readDeployLogo,
+} from "./api/deploy-config";
 export { clientUpdateApi } from "./api/clientUpdateApi";
 export type {
 	ClientApp,

--- a/frontend/private/README.md
+++ b/frontend/private/README.md
@@ -1,0 +1,34 @@
+# 私有化静态资源
+
+本目录存放客户私有化打包素材，**不要把客户文件提交到开源仓库**。
+
+```
+frontend/private/
+  README.md
+  logo/
+    {mode}/          # gitignore，客户标识目录
+      logo.svg       # 优先
+      logo.png       # 无 svg 时使用
+```
+
+## 规则
+
+- 环境变量 `LEROS_DEPLOY_MODE` 只用来选择 `logo/{mode}/`。
+- **未设置 mode**：不读本目录，安装包使用默认 Lework Logo。
+- **设置了 mode，但 `logo/{mode}/` 目录不存在**：仍打私有化包，使用默认 Lework Logo。
+- **设置了 mode，且目录存在并含 `logo.svg` 或 `logo.png`**：把该 Logo 打进安装包。
+- **目录存在但没有 Logo 文件**：打包失败（避免空品牌包）。
+- `LEROS_DEPLOY_APP_NAME` 可选；不填则品牌名仍为 Lework。
+
+本地示例：
+
+```bash
+# 私有化，沿用官方 Logo
+LEROS_DEPLOY_MODE=acme pnpm dist:desktop:private:win:x64
+
+# 私有化并替换 Logo（先放好 frontend/private/logo/acme/logo.svg）
+LEROS_DEPLOY_MODE=acme pnpm dist:desktop:private:win:x64
+
+# 同时替换品牌名
+LEROS_DEPLOY_MODE=acme LEROS_DEPLOY_APP_NAME=AcmeAI pnpm dist:desktop:private:win:x64
+```

--- a/frontend/private/logo/.gitkeep
+++ b/frontend/private/logo/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory; customer mode folders are gitignored.


### PR DESCRIPTION
- 打包前按 mode 读取 frontend/private/logo，写入配置并生成安装包图标；未设 mode 或目录不存在则沿用 Lework（方案未定，暂时无法实现）
- 客户 logo 目录存在但缺少文件时直接失败，避免打出空品牌包
- 应用内品牌优先用 localStorage，其次用注入配置，最后才是默认 Lework
- 私有化包上传到 COS application/private/{mode}/，不覆盖 SaaS LATEST 与自动更新
- 用 environment=private 触发私有化打包，去掉独立的 desktop_deployment_mode
- 选 private 时跳过 k3s 客户端版本更新和服务端 deploy