### PR TITLE
fix(auth): 私有化登录按 GlobalConfig 二选一，并弱化服务地址文案

### DIFF
--- a/frontend/packages/app-ui/components/auth/AuthDialog.tsx
+++ b/frontend/packages/app-ui/components/auth/AuthDialog.tsx
@@ -11,6 +11,7 @@ import {
 	useAuthStore,
 	useChatStore,
 	useDAStore,
+	useGlobalConfigStore,
 	useLayoutStore,
 	usePermissionStore,
 } from "@leros/store";
@@ -341,8 +342,10 @@ function AuthDialog({
 	onOpenChange: (open: boolean) => void;
 	onAuthenticated: (login: PendingOrganizationLoginResponse) => Promise<void>;
 }) {
-	// 中文注释：私有化仅账号密码；其余（SaaS）仅手机号验证码。不依赖 GlobalConfig 开关。
-	const mode: AuthMode = isPrivateDeployment ? "password" : "phone";
+	const phoneCodeLoginEnabled = useGlobalConfigStore((s) => s.phoneCodeLoginEnabled);
+	// 中文注释：私有化客户端按 GlobalConfig 二选一；SaaS 客户端固定手机号，与填了什么服务地址无关。
+	const mode: AuthMode =
+		isPrivateDeployment && !phoneCodeLoginEnabled ? "password" : "phone";
 	const [phone, setPhone] = useState("");
 	const [code, setCode] = useState("");
 	const [account, setAccount] = useState("");
@@ -385,14 +388,9 @@ function AuthDialog({
 	const normalizedAccount = account.trim();
 	const phoneValid = /^1[3-9]\d{9}$/.test(normalizedPhone);
 	const codeValid = /^\d{4,8}$/.test(normalizedCode);
-	// 中文注释：私有化仅支持邮箱登录；其他环境含 @ 为邮箱，否则为手机号。
+	// 中文注释：账密登录仅校验邮箱；手机号验证码走另一套表单。
 	const accountValid =
-		normalizedAccount.length > 0 &&
-		(isPrivateDeployment
-			? /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedAccount)
-			: normalizedAccount.includes("@")
-				? /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedAccount)
-				: /^1[3-9]\d{9}$/.test(normalizedAccount));
+		normalizedAccount.length > 0 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedAccount);
 	const passwordValid = password.length >= 8;
 	const canSubmitPhone = phoneValid && codeValid && agreed;
 	const canSubmitPassword = accountValid && passwordValid && agreed;
@@ -608,24 +606,16 @@ function AuthDialog({
 					) : (
 						<form onSubmit={handlePasswordSubmit} className="mt-5 flex w-full flex-col gap-3">
 							<DialogDescription className="text-center text-sm text-[#8b95a5]">
-								{isPrivateDeployment ? "使用邮箱登录" : "使用邮箱或手机号登录"}
+								使用邮箱登录
 							</DialogDescription>
-							<FieldWithError
-								error={
-									showAccountError
-										? isPrivateDeployment
-											? "请输入正确的邮箱"
-											: "请输入正确的邮箱或手机号"
-										: undefined
-								}
-							>
+							<FieldWithError error={showAccountError ? "请输入正确的邮箱" : undefined}>
 								<AuthField icon={<Mail className="size-4" />} invalid={showAccountError}>
 									<Input
 										type="text"
 										value={account}
 										onChange={(event) => setAccount(event.target.value)}
 										onBlur={handleFieldBlur("account")}
-										placeholder={isPrivateDeployment ? "请输入邮箱" : "请输入邮箱或手机号"}
+										placeholder="请输入邮箱"
 										className="h-[52px] border-0 bg-transparent px-0 text-base text-[#070d1c] shadow-none placeholder:text-[#9aa3b2] focus-visible:ring-0"
 									/>
 								</AuthField>

--- a/frontend/packages/app-ui/components/private-deployment/PrivateDeploymentGate.test.tsx
+++ b/frontend/packages/app-ui/components/private-deployment/PrivateDeploymentGate.test.tsx
@@ -50,7 +50,7 @@ describe("PrivateDeploymentGate", () => {
 		});
 
 		expect(container.querySelector('[data-testid="application"]')).not.toBeNull();
-		expect(document.body.textContent).not.toContain("连接私有化服务");
+		expect(document.body.textContent).not.toContain("连接服务");
 	});
 
 	it("blocks the application with a dialog that has no close button", () => {
@@ -65,7 +65,9 @@ describe("PrivateDeploymentGate", () => {
 		});
 
 		expect(container.querySelector('[data-testid="application"]')).toBeNull();
-		expect(document.body.textContent).toContain("连接私有化服务");
+		expect(document.body.textContent).toContain("连接服务");
+		expect(document.body.textContent).not.toContain("Lework");
+		expect(document.body.textContent).not.toContain("私有化");
 		expect(document.querySelector('[data-slot="dialog-close"]')).toBeNull();
 	});
 

--- a/frontend/packages/app-ui/components/private-deployment/PrivateDeploymentGate.tsx
+++ b/frontend/packages/app-ui/components/private-deployment/PrivateDeploymentGate.tsx
@@ -72,9 +72,9 @@ function PrivateServerSetupDialog({ onReload }: { onReload: () => void }) {
 							<Server className="size-6" />
 						</div>
 						<DialogHeader>
-							<DialogTitle className="text-2xl text-slate-950">连接私有化服务</DialogTitle>
+							<DialogTitle className="text-2xl text-slate-950">连接服务</DialogTitle>
 							<DialogDescription className="leading-6 text-slate-600">
-								首次使用前，请配置 Lework 后端服务地址。连接测试通过后才能进入应用。
+								首次使用前，请配置后端服务地址。连接测试通过后即可进入应用。
 							</DialogDescription>
 						</DialogHeader>
 					</div>
@@ -91,7 +91,7 @@ function PrivateServerSetupDialog({ onReload }: { onReload: () => void }) {
 									setErrorMessage("");
 									setConnectionPassed(false);
 								}}
-								placeholder="https://leros.example.com"
+								placeholder="http://192.144.230.208:38081"
 								autoFocus
 								disabled={testing}
 								aria-invalid={Boolean(errorMessage)}

--- a/frontend/packages/store/api/globalConfigApi.ts
+++ b/frontend/packages/store/api/globalConfigApi.ts
@@ -7,7 +7,7 @@ export type GlobalConfig = {
 	edition: Edition;
 	/** 每个用户可创建的组织上限；达到后前端禁用创建组织入口。 */
 	max_orgs_per_user: number;
-	/** 是否开启手机号验证码登录（服务端透传；前端登录 UI 以私有化客户端标记为准） */
+	/** 是否开启手机号验证码登录（服务端透传；私有化客户端据此只展示手机号或只展示邮箱账密） */
 	phone_code_login_enabled: boolean;
 };
 

--- a/frontend/packages/store/slices/globalConfigSlice.ts
+++ b/frontend/packages/store/slices/globalConfigSlice.ts
@@ -8,8 +8,8 @@ export type GlobalConfigState = {
 	/** null 表示尚未拉到 GlobalConfig，不做数量上限判断。 */
 	maxOrgsPerUser: number | null;
 	/**
-	 * 是否开启手机号验证码登录（GlobalConfig 透传；登录 UI 不以此为准）。
-	 * 登录展示以客户端 isPrivateDeployment 为准：私有化账密，其余验证码。
+	 * 是否开启手机号验证码登录（GlobalConfig 透传）。
+	 * 私有化客户端据此二选一：true 仅手机号，false 仅邮箱账密；SaaS 客户端固定仅手机号。
 	 */
 	phoneCodeLoginEnabled: boolean;
 };
@@ -56,16 +56,14 @@ export class GlobalConfigActionImpl {
 			if (result.code !== 0 || !result.data?.edition) return false;
 
 			const maxOrgsPerUser = result.data.max_orgs_per_user;
-			// 中文注释：edition / 组织上限以服务端为准；私有化客户端不展示验证码登录，忽略服务端该开关。
+			// 中文注释：edition / 组织上限 / 验证码登录开关均以服务端为准。
 			this.#set({
 				edition: result.data.edition,
 				maxOrgsPerUser:
 					typeof maxOrgsPerUser === "number" && Number.isFinite(maxOrgsPerUser)
 						? maxOrgsPerUser
 						: null,
-				phoneCodeLoginEnabled: isPrivateDeployment
-					? false
-					: result.data.phone_code_login_enabled !== false,
+				phoneCodeLoginEnabled: result.data.phone_code_login_enabled !== false,
 			});
 			return true;
 		} catch (error) {


### PR DESCRIPTION
- 私有化客户端（需填服务地址）按 phone_code_login_enabled 只展示手机号或只展示邮箱账密，不再固定邮箱、也不再同时给两种方式
- SaaS 客户端仍只展示手机号；填了 SaaS 地址的私有化客户端仍按上述开关二选一
- 首次连接弹窗去掉「私有化」和品牌名，避免后续统一走地址接入时文案过死
- 服务地址占位符改为私有化 POC 地址，方便对接调试