### PR TITLE
fix(worker-base): 预装 ripgrep，避免 OpenCode 加载 skill 时下载 rg

### DIFF
--- a/deployments/build/Dockerfile.worker-base
+++ b/deployments/build/Dockerfile.worker-base
@@ -25,6 +25,8 @@ RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.aliyun.com/ubuntu
 # - CJK 字体与替代字体：保证中文文档正常渲染
 # - python3.12 + python3-pip：文档处理运行时
 # - fontconfig、libsqlite3-0 等：基础工具链
+# - ripgrep：OpenCode 的 skill/grep/glob 依赖 PATH 上的 rg；未安装时会在运行时从
+#   GitHub Releases 下载，测试/生产出网失败会长时间卡住并报 ripgrep execution failed
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     tzdata \
@@ -38,6 +40,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pandoc \
     python3.12 \
     python3-pip \
+    ripgrep \
     fonts-noto-cjk \
     fonts-noto-cjk-extra \
     fonts-wqy-zenhei \
@@ -45,7 +48,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     fonts-arphic-uming \
     fonts-arphic-ukai \
     fontconfig \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rg --version
 
 # Map common Windows/MS Office CJK font names to the installed Noto/WenQuanYi fonts,
 # so LibreOffice documents requesting SimSun/SimHei/FangSong/KaiTi/Microsoft YaHei/

--- a/deployments/build/README.md
+++ b/deployments/build/README.md
@@ -25,6 +25,7 @@
 | CJK 字体 + Windows 字体别名表 | ✅ | ✅ |
 | Python 3.12 + pip 镜像 | ✅ | ✅ |
 | Node.js 22.14 + claude-code/codex/opencode | ✅ | ✅ |
+| ripgrep（OpenCode skill/grep/glob，避免运行时从 GitHub 拉 rg） | ✅ | ✅ |
 | Python 文档库（python-docx、lxml、openpyxl、xlsxwriter、pandas、python-pptx、PyMuPDF、pypdf、pdfplumber、pdfminer.six、reportlab、Pillow） | ✅ | ✅ |
 | Node 文档组件（docx、PptxGenJS、pdf-lib、sharp） | ✅ | ✅ |
 | TeX Live（XeLaTeX/LuaLaTeX/pdfLaTeX + 中文字体） | ❌ | ✅ |

--- a/deployments/build/worker-base.versions.txt
+++ b/deployments/build/worker-base.versions.txt
@@ -49,6 +49,7 @@ PLAYWRIGHT=1.61.1
 #                    tesseract-ocr-osd
 #   其余          -> poppler-utils / ghostscript / pandoc / imagemagick /
 #                    inkscape / python3-matplotlib / ffmpeg / libvips
+#   ripgrep       -> OpenCode skill/grep/glob（两版共用，避免运行时从 GitHub 拉 rg）
 
 # pip 镜像（默认阿里云）
 PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/


### PR DESCRIPTION
- OpenCode 的 skill/grep/glob 依赖 PATH 上的 rg，缺失时会从 GitHub Releases 拉取，出网慢或失败会卡住并报 ripgrep execution failed
- worker-base 两版 apt 预装 ripgrep，构建时用 rg --version 校验
- 顺带：同步构建说明与版本清单