### PR TITLE
fix(payroll): 稳定历史表读取，并修正人员类别与按项目排列

### DIFF
--- a/backend/skills/server/attendance-payroll/scripts/payroll_calculator.py
+++ b/backend/skills/server/attendance-payroll/scripts/payroll_calculator.py
@@ -31,6 +31,10 @@ ERROR_INPUT = 2
 ERROR_BLOCKED = 3
 ERROR_OUTPUT = 4
 MONEY = "0.00"
+# 人工工资表格式化整列时，openpyxl 会把 used range 扩到十几万行。
+MAX_SHEET_ROWS = 2000
+MAX_SHEET_COLS = 48
+EMPTY_ROW_STOP = 40
 
 # Workbook sheet titles written by this calculator. A file that contains all of
 # them is a generated result, not a human historical payroll sheet.
@@ -175,7 +179,8 @@ def source_hints(path: Path) -> tuple[str, str]:
     if "劳务派遣" in name:
         category = "劳务派遣"
     else:
-        vendor = re.search(r"((?:(?![年月日])[\u4e00-\u9fff]){2,4}外包)", name)
+        # 「5月份甲司外包」里的「份」属于月份，不能算进供应商简称。
+        vendor = re.search(r"((?:(?![年月日份])[\u4e00-\u9fff]){2,4}外包)", name)
         if vendor:
             category = vendor.group(1)
         elif "外包" in name:
@@ -183,7 +188,7 @@ def source_hints(path: Path) -> tuple[str, str]:
         elif "外聘" in name:
             category = "外聘"
         else:
-            dated = re.match(r"^.+?20\d{2}年(?:\d{1,2}月)?(.*)$", name)
+            dated = re.match(r"^.+?20\d{2}年(?:\d{1,2}月份?)?(.*)$", name)
             if dated:
                 tail = re.sub(r"\.(xlsx|xls)$", "", dated.group(1), flags=re.I)
                 tail = re.sub(r"(?:人员)?(?:工资表|工资).*$", "", clean(tail))
@@ -262,11 +267,18 @@ def formula_cell_number(
     return number(value)
 
 
+def is_blank_row(values: list[Any] | tuple[Any, ...]) -> bool:
+    return all(value is None or (isinstance(value, str) and not value.strip()) for value in values)
+
+
 def worksheet_values(sheet: Any) -> list[tuple[Any, ...]]:
     """Return display values while preserving formulas without cached Excel results."""
     cache: dict[str, float | None] = {}
-    rows = []
-    for row in sheet.iter_rows():
+    rows: list[tuple[Any, ...]] = []
+    empty_streak = 0
+    max_row = min(sheet.max_row or 1, MAX_SHEET_ROWS)
+    max_col = min(sheet.max_column or 1, MAX_SHEET_COLS)
+    for row in sheet.iter_rows(min_row=1, max_row=max_row, max_col=max_col):
         values = []
         for cell in row:
             value = cell.value
@@ -275,6 +287,13 @@ def worksheet_values(sheet: Any) -> list[tuple[Any, ...]]:
                 values.append(resolved if resolved is not None else value)
             else:
                 values.append(value)
+        if is_blank_row(values):
+            empty_streak += 1
+            if empty_streak >= EMPTY_ROW_STOP and any(not is_blank_row(item) for item in rows):
+                break
+            rows.append(tuple(values))
+            continue
+        empty_streak = 0
         rows.append(tuple(values))
     return rows
 
@@ -931,6 +950,10 @@ def calculate(
             or clean(roster_row.get("category")) or clean(base.get("category"))
             or clean(roster_row.get("_category_hint")) or clean(base.get("_category_hint"))
         )
+        # 底表和历史都没有此人时，考勤 JSON 里的类别是识图猜测，不能当成用工类别。
+        if not roster_row and not base:
+            resolved_category = ""
+            issues.append("未在底表和历史工资中匹配，人员类别未认定")
         if len(records) > 1:
             issues.append("同一姓名+项目+类别存在多条考勤记录")
         actual, personal_leave = attendance_days(record, month)
@@ -1053,8 +1076,28 @@ def calculate(
         exceptions.append({"姓名": row.get("name"), "项目": row.get("project"),
                            "人员类别": "在册", "类型": "可忽略",
                            "说明": "在册人员不进入外聘工资核算"})
-    return {"payroll_detail": details, "baseline": baselines, "attendance": attendance_out,
-            "reconciliation": reconciliation, "review_exceptions": exceptions}
+    return {
+        "payroll_detail": grouped_by_project(details),
+        "baseline": grouped_by_project(baselines),
+        "attendance": grouped_by_project(attendance_out),
+        "reconciliation": grouped_by_project(reconciliation),
+        "review_exceptions": grouped_by_project(exceptions),
+    }
+
+
+def grouped_by_project(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep each project as a contiguous block, in the order projects first appear."""
+    project_order: dict[str, int] = {}
+    for row in rows:
+        key = clean(row.get("项目"))
+        if key not in project_order:
+            project_order[key] = len(project_order)
+    return [
+        row for _, row in sorted(
+            enumerate(rows),
+            key=lambda item: (project_order[clean(item[1].get("项目"))], item[0]),
+        )
+    ]
 
 
 def write_workbook(result: dict[str, list[dict[str, Any]]], output: Path) -> None:

--- a/backend/skills/server/attendance-payroll/tests/test_payroll_calculator.py
+++ b/backend/skills/server/attendance-payroll/tests/test_payroll_calculator.py
@@ -2,6 +2,7 @@ import io
 import json
 import sys
 import tempfile
+import time
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -256,6 +257,19 @@ class PayrollCalculatorTest(unittest.TestCase):
         )
         self.assertEqual(rows["payroll_detail"], [])
 
+    def test_unmatched_person_does_not_keep_attendance_category(self):
+        rows = calculate(
+            [],
+            [],
+            [{"name": "周八", "project": "A项目", "category": "甲司外包",
+              "actual_work_days": 21}],
+            "2026-06", None, None, attendance_project="A项目",
+        )
+        detail = rows["payroll_detail"][0]
+        self.assertEqual(detail["项目"], "A项目")
+        self.assertEqual(detail["人员类别"], "")
+        self.assertTrue(any("人员类别未认定" in item["说明"] for item in rows["review_exceptions"]))
+
     def test_ignored_review_always_uses_enrolled_category(self):
         rows = calculate(
             [{"name": "钱在册", "project": "A项目", "category": "项目经理", "status": "在册"}],
@@ -427,6 +441,27 @@ class PayrollCalculatorTest(unittest.TestCase):
             )
             self.assertEqual({row["姓名"] for row in rows["payroll_detail"]}, {"甲", "乙"})
 
+    def test_payroll_rows_keep_each_project_contiguous(self):
+        rows = calculate(
+            [],
+            [
+                {"name": "乙", "project": "B项目", "category": "外包",
+                 "position_salary": 2000, "performance": 1000},
+                {"name": "甲", "project": "A项目", "category": "外包",
+                 "position_salary": 2000, "performance": 1000},
+                {"name": "丙", "project": "A项目", "category": "外包",
+                 "position_salary": 2000, "performance": 1000},
+            ],
+            [
+                {"name": "甲", "project": "A项目", "category": "外包", "actual_work_days": 21},
+                {"name": "乙", "project": "B项目", "category": "外包", "actual_work_days": 21},
+                {"name": "丙", "project": "A项目", "category": "外包", "actual_work_days": 21},
+            ],
+            "2026-06", None, None,
+        )
+        self.assertEqual([row["项目"] for row in rows["payroll_detail"]], ["A项目", "A项目", "B项目"])
+        self.assertEqual([row["姓名"] for row in rows["payroll_detail"]], ["甲", "丙", "乙"])
+
     def test_conflicting_attendance_months_are_blocked(self):
         with tempfile.TemporaryDirectory() as directory:
             first = Path(directory) / "june.json"
@@ -457,7 +492,15 @@ class PayrollCalculatorTest(unittest.TestCase):
         path = Path("B项目2026年5月甲司外包人员工资表.xlsx")
         self.assertEqual(source_hints(path), ("B项目", "甲司外包"))
         self.assertEqual(
+            source_hints(Path("B项目2026年5月份甲司外包人员工资表.xlsx")),
+            ("B项目", "甲司外包"),
+        )
+        self.assertEqual(
             source_hints(Path("B项目2026年5月甲司人员工资表.xlsx")),
+            ("B项目", "甲司"),
+        )
+        self.assertEqual(
+            source_hints(Path("B项目2026年5月份甲司人员工资表.xlsx")),
             ("B项目", "甲司"),
         )
 
@@ -537,6 +580,22 @@ class PayrollCalculatorTest(unittest.TestCase):
         )
         self.assertEqual(rows["payroll_detail"][0]["事假天数"], 0)
         self.assertEqual(rows["payroll_detail"][0]["绩效工资"], 2175)
+
+    def test_sparse_excel_used_range_does_not_scan_the_whole_sheet(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "B项目2026年5月外包人员工资表.xlsx"
+            workbook = Workbook()
+            sheet = workbook.active
+            sheet.append(["姓名", "项目", "人员类别", "基本工资", "绩效工资"])
+            sheet.append(["张三", "B项目", "外包", 3200, 4200])
+            sheet.cell(row=50000, column=1, value="远行")
+            workbook.save(path)
+            started = time.perf_counter()
+            rows = read_rows(path)
+            self.assertLess(time.perf_counter() - started, 2)
+            names = [row.get("name") for row in rows]
+            self.assertIn("张三", names)
+            self.assertNotIn("远行", names)
 
     def test_personal_leave_requires_shi_mark_not_month_remainder(self):
         history = [{"name": "周七", "project": "C项目", "category": "外包",


### PR DESCRIPTION
- 历史工资表格式化后 used range 过大时，不再整表扫描空白区，避免计算器拖死
- 文件名里的「份」不再误切进供应商简称；底表和历史都没有的人，不把识图类别当成用工类别
- 核算结果按项目连续排列，避免同一项目人员被交叉打断