### PR TITLE
fix(workbench): 标书对比收口到工作台并理清页面命名

### DIFF
--- a/docs/frontend/components-layout.md
+++ b/docs/frontend/components-layout.md
@@ -58,7 +58,8 @@ packages/app-ui/components/layout/
 ├── CenterCanvas.tsx    # 中栏 - 聊天交互区
 ├── ConversationListPanel.tsx # 会话列表面板
 ├── RightRail.tsx       # 右栏 - 快捷/收件/工件
-├── WorkbenchPanel.tsx  # 工作台占位/入口面板
+├── WorkbenchPage.tsx   # 工作台功能入口（工资核算、标书对比等）
+├── NewTaskPage.tsx     # 新建任务首页
 └── index.ts            # barrel 导出
 ```
 
@@ -99,7 +100,7 @@ accordion, alert, alert-dialog, aspect-ratio, avatar, badge, breadcrumb, button,
 packages/app-ui/components/
 ├── chat/              # AI/User 消息气泡、时间轴、工具调用、欢迎页
 ├── input/             # ChatInput
-├── layout/            # Shell、LeftRail、CenterCanvas、WorkbenchPanel
+├── layout/            # Shell、LeftRail、WorkbenchPage、NewTaskPage
 └── digitalAssistant/  # Assistant 列表、卡片、详情、创建/编辑/删除弹窗
 ```
 
@@ -146,7 +147,7 @@ apps/web/app/page.tsx
       │   ├─ ChatHeader
       │   ├─ MessageTimeline
       │   └─ ChatInput
-      └─ WorkbenchPanel / AssistantListView
+      └─ NewTaskPage / WorkbenchPage / AssistantListView
 
 apps/desktop/src/renderer/src/routes.tsx
   └─ @lework/app-ui Shell

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -153,7 +153,7 @@ const nextConfig: NextConfig = {
 
 `@lework/app-ui` 承载 Web 与 Desktop 共用的业务组合组件：
 
-- `components/layout`：`Shell`、`LeftRail`、`CenterCanvas`、`WorkbenchPanel`
+- `components/layout`：`Shell`、`LeftRail`、`WorkbenchPage`、`NewTaskPage`
 - `components/chat`：消息气泡、时间轴、欢迎页、工具调用展示
 - `components/input`：`ChatInput`
 - `components/digitalAssistant`：列表、详情、创建/编辑/删除弹窗

--- a/frontend/apps/desktop/src/renderer/src/routes.tsx
+++ b/frontend/apps/desktop/src/renderer/src/routes.tsx
@@ -3,13 +3,13 @@ import {
 	AutomationExecutionPage,
 	AutomationListView,
 	OrgAdminPage,
-	PayrollWorkbench,
+	WorkbenchPage,
 	ProjectPage,
 	ProjectsHubView,
 	Shell,
 	SkillMarketView,
 	TaskDetailPage,
-	WorkbenchPanel,
+	NewTaskPage,
 } from "@leros/app-ui";
 
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -24,7 +24,7 @@ export function AppRoutes() {
 			<Routes>
 				<Route path="/" element={<Navigate to="/chat" replace />} />
 
-				<Route path="/chat" element={<ChatRoutePage />} />
+				<Route path="/chat" element={<NewTaskRoutePage />} />
 
 				<Route path="/workbench" element={<WorkbenchRoutePage />} />
 
@@ -137,13 +137,13 @@ function useDesktopNavigation(): AppNavigation {
 function WorkbenchRoutePage() {
 	const navigation = useDesktopNavigation();
 
-	return <PayrollWorkbench navigation={navigation} />;
+	return <WorkbenchPage navigation={navigation} />;
 }
 
-function ChatRoutePage() {
+function NewTaskRoutePage() {
 	const navigation = useDesktopNavigation();
 
-	return <WorkbenchPanel navigation={navigation} />;
+	return <NewTaskPage navigation={navigation} />;
 }
 
 function projectTabPath(projectId: string, tab: "chat" | "tasks" | "files" | "activity"): string {

--- a/frontend/apps/web/app/(shell)/chat/page.tsx
+++ b/frontend/apps/web/app/(shell)/chat/page.tsx
@@ -1,5 +1,5 @@
-import { ChatRoutePage } from "../../../components/route-pages";
+import { NewTaskRoutePage } from "../../../components/route-pages";
 
 export default function Page() {
-	return <ChatRoutePage />;
+	return <NewTaskRoutePage />;
 }

--- a/frontend/apps/web/app/(shell)/skills/[skillId]/page.tsx
+++ b/frontend/apps/web/app/(shell)/skills/[skillId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SkillDetailView, buildSkillWorkbenchPrefill } from "@leros/app-ui";
+import { SkillDetailView, buildSkillNewTaskPrefill } from "@leros/app-ui";
 import { useLayoutStore } from "@leros/store";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback } from "react";
@@ -27,7 +27,7 @@ export default function SkillDetailPage() {
 				return;
 			}
 
-			const prefill = buildSkillWorkbenchPrefill(nextSkillId, undefined, displayLabel);
+			const prefill = buildSkillNewTaskPrefill(nextSkillId, undefined, displayLabel);
 			setProjectComposerPrefill({
 				projectId: targetProjectId,
 				value: prefill.value,

--- a/frontend/apps/web/app/(shell)/workbench/page.tsx
+++ b/frontend/apps/web/app/(shell)/workbench/page.tsx
@@ -1,5 +1,5 @@
 import { WorkbenchRoutePage } from "@/components/route-pages";
 
-export default function WorkbenchPage() {
+export default function WorkbenchRoute() {
 	return <WorkbenchRoutePage />;
 }

--- a/frontend/apps/web/components/route-pages.tsx
+++ b/frontend/apps/web/components/route-pages.tsx
@@ -6,10 +6,10 @@ import {
 	OrgAdminPage,
 	ProjectPage,
 	ProjectsHubView,
-	PayrollWorkbench,
+	WorkbenchPage,
 	SkillMarketView,
 	TaskDetailPage,
-	WorkbenchPanel,
+	NewTaskPage,
 } from "@leros/app-ui";
 import { useParams, useRouter } from "next/navigation";
 import { useWebNavigation } from "./LerosShell";
@@ -26,13 +26,13 @@ function projectTabPath(projectId: string, tab: ProjectTab): string {
 export function WorkbenchRoutePage() {
 	const navigation = useWebNavigation();
 
-	return <PayrollWorkbench navigation={navigation} />;
+	return <WorkbenchPage navigation={navigation} />;
 }
 
-export function ChatRoutePage() {
+export function NewTaskRoutePage() {
 	const navigation = useWebNavigation();
 
-	return <WorkbenchPanel navigation={navigation} />;
+	return <NewTaskPage navigation={navigation} />;
 }
 
 export function ProjectRoutePage({ tab = "chat" }: { tab?: ProjectTab }) {

--- a/frontend/packages/app-ui/components/digitalAssistant/AssistantListView.tsx
+++ b/frontend/packages/app-ui/components/digitalAssistant/AssistantListView.tsx
@@ -17,8 +17,8 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useAuth } from "../auth";
 import type { AppNavigation } from "../layout";
-import { navigateToWorkbench } from "../layout/workbench-navigation";
-import { buildAssistantWorkbenchPrefill } from "../layout/workbench-prefill";
+import { navigateToNewTask } from "../layout/new-task-navigation";
+import { buildAssistantNewTaskPrefill } from "../layout/new-task-prefill";
 import { AssistantAvatar } from "./AssistantAvatar";
 import { AssistantCard } from "./AssistantCard";
 import { AssistantCreateDialog } from "./AssistantCreateDialog";
@@ -127,9 +127,9 @@ export function AssistantListView({ navigation }: { navigation?: AppNavigation }
 			selectWorkbenchProject(null);
 			selectWorkbenchTask(null);
 			setWorkbenchComposerPrefill(
-				buildAssistantWorkbenchPrefill(assistantIdentity, assistant, prompt),
+				buildAssistantNewTaskPrefill(assistantIdentity, assistant, prompt),
 			);
-			navigateToWorkbench(navigation, switchView);
+			navigateToNewTask(navigation, switchView);
 			toast.success(`已成功召唤 ${assistant.name}`);
 			setDetailTarget(null);
 		});

--- a/frontend/packages/app-ui/components/input/BidComparisonConfigDialog.tsx
+++ b/frontend/packages/app-ui/components/input/BidComparisonConfigDialog.tsx
@@ -77,10 +77,6 @@ export function BidComparisonConfigDialog({
 	projects = [],
 	initialProjectId,
 	initialTaskId,
-	hideTargetPicker = false,
-	allowSelectTask = true,
-	lockProjectSelection = false,
-	continueInCurrentTask = false,
 	onProjectChange,
 }: {
 	open: boolean;
@@ -89,14 +85,6 @@ export function BidComparisonConfigDialog({
 	projects?: BidComparisonProjectOption[];
 	initialProjectId?: string | null;
 	initialTaskId?: string | null;
-	/** 项目新建任务 / 任务详情等已有默认目标时，不展示项目任务选择。 */
-	hideTargetPicker?: boolean;
-	/** 与工作台问答一致：可选已有任务；为 false 时仅选项目（隐含新建任务）。 */
-	allowSelectTask?: boolean;
-	/** 项目中新建任务固定当前项目，避免跨项目创建。 */
-	lockProjectSelection?: boolean;
-	/** 任务详情续聊场景，用于文案提示。 */
-	continueInCurrentTask?: boolean;
 	onProjectChange?: (projectId: string) => void;
 }) {
 	const [targetProjectId, setTargetProjectId] = useState(initialProjectId ?? "");
@@ -129,13 +117,7 @@ export function BidComparisonConfigDialog({
 		}
 	}, [onProjectChange, open, targetProjectId]);
 
-	const dialogDescription = continueInCurrentTask
-		? "选择文件后，将在当前任务中开始标书对比"
-		: hideTargetPicker
-			? "选择文件后，将新建任务并开始标书对比"
-			: allowSelectTask
-				? "选择项目/任务与文件后，开始标书对比"
-				: "选择项目与文件后，将新建任务并开始标书对比";
+	const dialogDescription = "选择项目/任务与文件后，开始标书对比";
 
 	const chooseUploadedFiles = (files: FileList | null, kind: "main" | "compare") => {
 		const selectedFiles = Array.from(files ?? []).map(
@@ -187,7 +169,7 @@ export function BidComparisonConfigDialog({
 		try {
 			await onSave({
 				projectId: targetProjectId || undefined,
-				taskId: allowSelectTask || continueInCurrentTask ? targetTaskId || undefined : undefined,
+				taskId: targetTaskId || undefined,
 				mainFile,
 				compareFiles,
 				reportFormat,
@@ -211,31 +193,26 @@ export function BidComparisonConfigDialog({
 							<BidComparisonIcon className="size-5" />
 						</div>
 						<div>
-							<DialogTitle className="text-base">
-								{continueInCurrentTask ? "标书对比" : "新建标书对比"}
-							</DialogTitle>
+							<DialogTitle className="text-base">标书对比</DialogTitle>
 							<DialogDescription className="mt-1 text-xs">{dialogDescription}</DialogDescription>
 						</div>
 					</div>
 				</DialogHeader>
 
 				<div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-7 py-5">
-					{!hideTargetPicker ? (
-						<ProjectTaskPickerField
-							projects={projects}
-							projectId={targetProjectId}
-							taskId={targetTaskId}
-							disabled={lockProjectSelection}
-							allowNewProject={!lockProjectSelection}
-							allowSelectTask={allowSelectTask}
-							onLoadProjectTasks={onProjectChange}
-							onSelect={(nextProjectId, nextTaskId) => {
-								setTargetProjectId(nextProjectId);
-								setTargetTaskId(nextTaskId);
-								if (nextProjectId) onProjectChange?.(nextProjectId);
-							}}
-						/>
-					) : null}
+					<ProjectTaskPickerField
+						projects={projects}
+						projectId={targetProjectId}
+						taskId={targetTaskId}
+						allowNewProject
+						allowSelectTask
+						onLoadProjectTasks={onProjectChange}
+						onSelect={(nextProjectId, nextTaskId) => {
+							setTargetProjectId(nextProjectId);
+							setTargetTaskId(nextTaskId);
+							if (nextProjectId) onProjectChange?.(nextProjectId);
+						}}
+					/>
 					<FilePickerSection
 						title="投标文件"
 						required

--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -67,16 +67,7 @@ import {
 	PROJECT_MCP_COLLABORATION_WARNING,
 } from "../layout/project-mcp-collaboration-warning";
 import { AttachmentPreview } from "./AttachmentPreview";
-import { type BidComparisonConfig, BidComparisonConfigDialog } from "./BidComparisonConfigDialog";
-import {
-	bidComparisonConfigToAttachments,
-	bidComparisonOutputFormat,
-	bidComparisonPrompt,
-	ensureBidComparisonFilesUploaded,
-} from "./bidComparisonAttachments";
 import { ComposerActionBar } from "./ComposerActionBar";
-import { BidComparisonEntryButton, ComposerUsageTipsPanel } from "./ComposerUsageTipsPanel";
-import { buildComposerUsageTips } from "./composerUsageTips";
 import { QuestionAnswerInput } from "./QuestionAnswerInput";
 import {
 	type ComposerAssistantOption,
@@ -93,20 +84,11 @@ export function ChatInput({
 	variant = "default",
 	projectLayoutMode = "sidebar-expanded",
 	navigation,
-	bidComparisonEntry = "auto",
 }: {
 	variant?: "default" | "project";
 	/** 项目页聊天区布局：随右侧栏展开/收起切换宽度与留白 */
 	projectLayoutMode?: ProjectChatLayoutMode;
 	navigation?: AppNavigation;
-	/**
-	 * 标书对比入口：
-	 * - auto：项目新建任务展示使用提示+按钮，任务详情仅按钮
-	 * - button：仅标书对比按钮（任务详情）
-	 * - tips：使用提示面板含标书对比
-	 * - none：不展示
-	 */
-	bidComparisonEntry?: "auto" | "button" | "tips" | "none";
 }) {
 	const projectAttachmentAccept = getComposerUploadAccept(
 		typeof navigator === "undefined" ? undefined : navigator.platform,
@@ -150,13 +132,11 @@ export function ChatInput({
 		currentView,
 		projectComposerPrefill,
 		projects,
-		fetchTasks,
 		consumeProjectComposerPrefill,
 	} = useLayoutStore((s) => s);
 	const { assistants, assistantsLoaded, fetchAssistants } = useDAStore((s) => s);
 
 	const composerRef = useRef<StructuredComposerHandle | null>(null);
-	const [bidComparisonOpen, setBidComparisonOpen] = useState(false);
 	const lastAppliedSelectionDraftRef = useRef<{
 		id: string;
 		suggestedPrompt?: string;
@@ -250,104 +230,6 @@ export function ChatInput({
 		[skillOptions],
 	);
 	const isNewProjectTaskView = isProjectVariant && currentView === "project";
-	const isTaskDetailView =
-		isProjectVariant &&
-		(currentView === "taskDetail" ||
-			Boolean(activeTaskDetailTaskId && activeTaskDetailSessionId && currentView !== "project"));
-	const showBidComparisonTips =
-		bidComparisonEntry === "tips" || (bidComparisonEntry === "auto" && isNewProjectTaskView);
-	const showBidComparisonButtonOnly =
-		bidComparisonEntry === "button" || (bidComparisonEntry === "auto" && isTaskDetailView);
-	const showBidComparisonDialog = showBidComparisonTips || showBidComparisonButtonOnly;
-	const composerUsageTips = useMemo(
-		() => (showBidComparisonTips ? buildComposerUsageTips(currentProject) : []),
-		[showBidComparisonTips, currentProject],
-	);
-	const applyUsageTip = useCallback(
-		(prompt: string) => {
-			if (composerRef.current) {
-				composerRef.current.setContent(prompt);
-				return;
-			}
-			setInputText(prompt);
-		},
-		[setInputText],
-	);
-	const startBidComparison = useCallback(
-		async (config: BidComparisonConfig) => {
-			if (composerLocked) return;
-			try {
-				const projectId = config.projectId || currentProjectId;
-				if (!projectId) {
-					toast.error("请先选择项目");
-					throw new Error("请先选择项目");
-				}
-				const resolved = await ensureBidComparisonFilesUploaded(config, projectId);
-				const attachments = bidComparisonConfigToAttachments(resolved);
-				const prompt = bidComparisonPrompt(resolved);
-				const outputFormat = bidComparisonOutputFormat(resolved);
-
-				if (bidComparisonEntry === "button" || isTaskDetailView) {
-					const taskId = activeTaskDetailTaskId;
-					const sessionId = activeTaskDetailSessionId;
-					if (!taskId || !sessionId) {
-						toast.error("当前任务会话未就绪");
-						throw new Error("当前任务会话未就绪");
-					}
-					const result = await sendTaskRoomMessage(
-						prompt,
-						{
-							projectId,
-							taskId,
-							sessionId,
-							scene: "bid_comparison",
-							outputFormat,
-						},
-						attachments,
-					);
-					if (!result) {
-						toast.error("启动标书对比失败，请稍后重试");
-						throw new Error("启动标书对比失败，请稍后重试");
-					}
-					return;
-				}
-
-				const taskEntry = await sendProjectMessage(prompt, projectId, attachments, undefined, {
-					scene: "bid_comparison",
-					outputFormat,
-				});
-				if (!taskEntry) {
-					toast.error("启动标书对比失败，请稍后重试");
-					throw new Error("启动标书对比失败，请稍后重试");
-				}
-				if (taskEntry.project_id && taskEntry.task_id && taskEntry.session_id) {
-					navigation?.goToTaskDetail(taskEntry.project_id, taskEntry.task_id, taskEntry.session_id);
-				}
-			} catch (err) {
-				console.error("ChatInput bid comparison upload error:", err);
-				const message = err instanceof Error ? err.message.trim() : "";
-				const alreadyToasted =
-					message === "请先选择项目" ||
-					message === "当前任务会话未就绪" ||
-					message === "启动标书对比失败，请稍后重试";
-				if (!alreadyToasted) {
-					toast.error(getRequestErrorMessage(err) ?? "启动标书对比失败");
-				}
-				throw err;
-			}
-		},
-		[
-			activeTaskDetailSessionId,
-			activeTaskDetailTaskId,
-			bidComparisonEntry,
-			currentProjectId,
-			isTaskDetailView,
-			navigation,
-			sendProjectMessage,
-			sendTaskRoomMessage,
-			composerLocked,
-		],
-	);
 	const activeProjectComposerPrefill =
 		isProjectVariant &&
 		currentView === "project" &&
@@ -706,40 +588,6 @@ export function ChatInput({
 			)}
 		>
 			<div className={cn("mx-auto w-full max-w-[1040px]", isProjectVariant && projectLayout.inner)}>
-				{showBidComparisonTips ? (
-					<ComposerUsageTipsPanel
-						tips={composerUsageTips}
-						onApply={applyUsageTip}
-						onBidComparisonClick={() => setBidComparisonOpen(true)}
-					/>
-				) : null}
-				{showBidComparisonButtonOnly ? (
-					<div className="mb-4">
-						<BidComparisonEntryButton
-							disabled={composerLocked}
-							onClick={() => setBidComparisonOpen(true)}
-						/>
-					</div>
-				) : null}
-				{showBidComparisonDialog ? (
-					<BidComparisonConfigDialog
-						open={bidComparisonOpen}
-						onOpenChange={setBidComparisonOpen}
-						onSave={startBidComparison}
-						initialProjectId={currentProjectId}
-						initialTaskId={showBidComparisonButtonOnly ? activeTaskDetailTaskId : null}
-						hideTargetPicker
-						allowSelectTask={false}
-						continueInCurrentTask={showBidComparisonButtonOnly}
-						lockProjectSelection
-						onProjectChange={fetchTasks}
-						projects={projects.map((project) => ({
-							id: project.id,
-							name: project.name,
-							tasks: project.tasks,
-						}))}
-					/>
-				) : null}
 				<div
 					className={cn(
 						// 中文注释：focus 时使用无偏移阴影，避免 shadow-xl 只在下方显影

--- a/frontend/packages/app-ui/components/input/ComposerUsageTipsPanel.tsx
+++ b/frontend/packages/app-ui/components/input/ComposerUsageTipsPanel.tsx
@@ -3,13 +3,11 @@
 import { cn } from "@leros/ui/lib/utils";
 import { ChevronRight, Lightbulb, Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
-import { BidComparisonIcon } from "../../assets";
 
 type ComposerUsageTipsPanelProps = {
 	tips: Array<{ id: string; label: string; prompt: string }>;
 	onApply: (prompt: string) => void;
 	className?: string;
-	onBidComparisonClick: () => void;
 };
 
 /** Windows ClearType 旋转文字易糊；仅在非 Windows 保留旋转动效。 */
@@ -18,47 +16,10 @@ function canUseCrispTextRotate(): boolean {
 	return !/win/i.test(navigator.platform) && !/windows/i.test(navigator.userAgent);
 }
 
-/** 标书对比入口按钮；任务详情等场景单独使用，不挂「使用提示」。 */
-export function BidComparisonEntryButton({
-	onClick,
-	disabled = false,
-	className,
-}: {
-	onClick: () => void;
-	disabled?: boolean;
-	className?: string;
-}) {
-	const [enableRotate, setEnableRotate] = useState(false);
-
-	useEffect(() => {
-		setEnableRotate(canUseCrispTextRotate());
-	}, []);
-
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			disabled={disabled}
-			aria-disabled={disabled}
-			className={cn(
-				// 中文注释：! 避免 ChatInput 全局 [data-slot=chat-input] button 覆盖主题字色。
-				"inline-flex max-w-full items-center gap-2 rounded-full border border-[var(--leros-primary)] px-3.5 py-2 text-left text-sm font-semibold !text-[var(--leros-primary)] transition hover:bg-[var(--leros-primary-softer)]",
-				enableRotate && !disabled && "hover:rotate-5",
-				disabled && "cursor-not-allowed opacity-50 hover:bg-transparent",
-				className,
-			)}
-		>
-			<BidComparisonIcon className="size-3.5" />
-			<span>标书对比</span>
-		</button>
-	);
-}
-
 export function ComposerUsageTipsPanel({
 	tips,
 	onApply,
 	className,
-	onBidComparisonClick,
 }: ComposerUsageTipsPanelProps) {
 	const [enableRotate, setEnableRotate] = useState(false);
 
@@ -73,8 +34,6 @@ export function ComposerUsageTipsPanel({
 				<span>使用提示</span>
 			</div>
 			<div className="flex min-w-0 flex-wrap items-center gap-2.5">
-				<BidComparisonEntryButton onClick={onBidComparisonClick} />
-				<span aria-hidden className="mx-0.5 h-5 border-l border-slate-200" />
 				{tips.map((tip) => (
 					<button
 						key={tip.id}

--- a/frontend/packages/app-ui/components/input/useComposerConnectorOptions.ts
+++ b/frontend/packages/app-ui/components/input/useComposerConnectorOptions.ts
@@ -80,7 +80,7 @@ export async function loadComposerConnectorOptions({
 
 /**
  * 输入框「添加连接器」候选 Hook。包装 loadComposerConnectorOptions，
- * 暴露加载状态与重新加载能力，供 ChatInput / WorkbenchPanel 消费。
+ * 暴露加载状态与重新加载能力，供 ChatInput / NewTaskPage 消费。
  */
 export function useComposerConnectorOptions({
 	projectId,

--- a/frontend/packages/app-ui/components/layout/NewTaskPage.tsx
+++ b/frontend/packages/app-ui/components/layout/NewTaskPage.tsx
@@ -38,16 +38,6 @@ import { toast } from "sonner";
 import { useAuth } from "../auth";
 import { isAssistantAvailable } from "../digitalAssistant/assistantStatus";
 import { AttachmentPreview } from "../input/AttachmentPreview";
-import {
-	type BidComparisonConfig,
-	BidComparisonConfigDialog,
-} from "../input/BidComparisonConfigDialog";
-import {
-	bidComparisonConfigToAttachments,
-	bidComparisonOutputFormat,
-	bidComparisonPrompt,
-	ensureBidComparisonFilesUploaded,
-} from "../input/bidComparisonAttachments";
 import { ComposerActionBar } from "../input/ComposerActionBar";
 import { ComposerUsageTipsPanel } from "../input/ComposerUsageTipsPanel";
 import { buildComposerUsageTips } from "../input/composerUsageTips";
@@ -165,7 +155,7 @@ function detectDesktopApp(): boolean {
 	return Boolean(win.electron ?? win.lerosDesktop);
 }
 
-export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
+export function NewTaskPage({ navigation }: { navigation?: AppNavigation }) {
 	const { name: brandName } = useBrandIdentity();
 	const composerUploadAccept = getComposerUploadAccept(
 		typeof navigator === "undefined" ? undefined : navigator.platform,
@@ -220,7 +210,6 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 	const [projectMenuOpen, setProjectMenuOpen] = useState(false);
 	const [projectSearch, setProjectSearch] = useState("");
 	const [isDesktopApp, setIsDesktopApp] = useState(false);
-	const [bidComparisonOpen, setBidComparisonOpen] = useState(false);
 	const applyingWorkbenchPrefillIdRef = useRef<string | null>(null);
 	const wasAuthenticatedRef = useRef(isAuthenticated);
 
@@ -349,7 +338,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 				setSelectedConnectorIds([]);
 			}
 		} catch (err) {
-			console.error("WorkbenchPanel createInitialMessage error:", err);
+			console.error("NewTaskPage createInitialMessage error:", err);
 			toast.error(`创建任务失败：${getRequestErrorMessage(err) ?? "请稍后重试"}`);
 		} finally {
 			sendingRef.current = false;
@@ -642,42 +631,6 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 		setInput(prompt);
 	}, []);
 
-	const startBidComparison = useCallback(
-		async (config: BidComparisonConfig) => {
-			try {
-				const resolved = await ensureBidComparisonFilesUploaded(config, config.projectId);
-				// 中文注释：与问答一致——有任务则续聊，无任务则新建；显式传 taskId（可为空）避免回落到工作台条旧选中。
-				const data = await sendWorkbenchMessage(
-					bidComparisonPrompt(resolved),
-					resolved.projectId,
-					executionMode,
-					bidComparisonConfigToAttachments(resolved),
-					undefined,
-					undefined,
-					undefined,
-					"bid_comparison",
-					bidComparisonOutputFormat(resolved),
-					resolved.taskId ?? null,
-				);
-				if (!data?.project_id || !data.task_id || !data.session_id) {
-					toast.error("启动标书对比失败，请确认所选任务未在回复中后重试");
-					throw new Error("启动标书对比失败，请确认所选任务未在回复中后重试");
-				}
-				if (navigation) {
-					navigation.goToTaskDetail(data.project_id, data.task_id, data.session_id);
-				}
-			} catch (err) {
-				console.error("WorkbenchPanel bid comparison upload error:", err);
-				const message = err instanceof Error ? err.message.trim() : "";
-				if (message !== "启动标书对比失败，请确认所选任务未在回复中后重试") {
-					toast.error(getRequestErrorMessage(err) ?? "启动标书对比失败");
-				}
-				throw err;
-			}
-		},
-		[executionMode, navigation, sendWorkbenchMessage],
-	);
-
 	const clearProjectTriggerText = useCallback(() => {
 		projectTriggerClearRef.current?.();
 		projectTriggerClearRef.current = null;
@@ -847,27 +800,9 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 						</div>
 					</div>
 
-					<ComposerUsageTipsPanel
-						tips={workbenchUsageTips}
-						onApply={applyUsageTip}
-						onBidComparisonClick={() => setBidComparisonOpen(true)}
-					/>
-					<BidComparisonConfigDialog
-						open={bidComparisonOpen}
-						onOpenChange={setBidComparisonOpen}
-						onSave={startBidComparison}
-						initialProjectId={activeWorkbenchProjectId}
-						initialTaskId={activeWorkbenchTaskId}
-						allowSelectTask
-						onProjectChange={fetchTasks}
-						projects={projects.map((project) => ({
-							id: project.id,
-							name: project.name,
-							tasks: project.tasks,
-						}))}
-					/>
+					<ComposerUsageTipsPanel tips={workbenchUsageTips} onApply={applyUsageTip} />
 
-					{/* 中文注释：工作台输入卡片与 ChatInput 的 project 变体保持同一套边框、阴影与内边距规范。 */}
+					{/* 中文注释：新建任务输入卡片与 ChatInput 的 project 变体保持同一套边框、阴影与内边距规范。 */}
 					{/* 中文注释：输入框保持完整圆角，和 Codex 一样作为上层卡片悬浮在项目选择条之上。 */}
 					<div className="relative z-10 flex flex-col rounded-2xl bg-white px-4 py-2 shadow-sm ring-1 ring-slate-200/70 transition-all focus-within:shadow-[0_0_24px_rgba(15,23,42,0.12)] focus-within:ring-slate-200/70">
 						<input
@@ -953,7 +888,7 @@ export function WorkbenchPanel({ navigation }: { navigation?: AppNavigation }) {
 									size="icon"
 									onClick={handleSend}
 									disabled={isSending || !input.trim() || hasUploadingAttachments}
-									// 中文注释：工作台发送按钮与项目/任务页保持同一视觉规格。
+									// 中文注释：新建任务发送按钮与项目/任务页保持同一视觉规格。
 									className="size-9 min-w-0 rounded-xl bg-black !text-white shadow-sm hover:bg-blue-700 disabled:bg-[#f3f3f4] disabled:!text-slate-400"
 								>
 									<SendHorizonal

--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -551,7 +551,6 @@ function ProjectChat({
 				variant="project"
 				projectLayoutMode={layoutMode}
 				navigation={navigation}
-				bidComparisonEntry="tips"
 			/>
 		</div>
 	);

--- a/frontend/packages/app-ui/components/layout/Shell.tsx
+++ b/frontend/packages/app-ui/components/layout/Shell.tsx
@@ -14,10 +14,10 @@ import { PermissionDeniedListener } from "../permission/PermissionDeniedListener
 import { FrontendEventTracker } from "../telemetry/FrontendEventTracker";
 import { FilePreviewHost } from "./FilePreviewHost";
 import { type AppNavigation, LeftRail } from "./LeftRail";
-import { PayrollWorkbench } from "./PayrollWorkbench";
+import { NewTaskPage } from "./NewTaskPage";
 import { ProjectPage } from "./ProjectPage";
 import { TaskDetailPage } from "./TaskDetailPage";
-import { WorkbenchPanel } from "./WorkbenchPanel";
+import { WorkbenchPage } from "./WorkbenchPage";
 
 export function Shell({
 	logoSrc,
@@ -75,8 +75,8 @@ export function Shell({
 				<LeftRail logoSrc={logoSrc} navigation={navigation} />
 				{children ?? (
 					<>
-						{currentView === "chat" && <WorkbenchPanel />}
-						{currentView === "workbench" && <PayrollWorkbench />}
+						{currentView === "chat" && <NewTaskPage />}
+						{currentView === "workbench" && <WorkbenchPage />}
 						{currentView === "tasks" && <EmptyPage />}
 						{currentView === "project" && <ProjectPage />}
 						{currentView === "taskDetail" && activeTaskDetailSessionId && (

--- a/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
+++ b/frontend/packages/app-ui/components/layout/TaskDetailPage.tsx
@@ -561,7 +561,6 @@ export function TaskDetailPage({
 						variant="project"
 						projectLayoutMode={taskChatLayoutMode}
 						navigation={navigation}
-						bidComparisonEntry="button"
 					/>
 				</main>
 

--- a/frontend/packages/app-ui/components/layout/WorkbenchPage.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPage.tsx
@@ -11,15 +11,25 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@leros/ui/components/ui/dialog";
+import { getRequestErrorMessage } from "@leros/ui/lib/request";
 import { cn } from "@leros/ui/lib/utils";
 import { Calculator, FileSpreadsheet, FolderOpen, Upload, X } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { BidComparisonIcon } from "../../assets";
 import { useAuth } from "../auth";
 import {
+	type BidComparisonConfig,
+	BidComparisonConfigDialog,
 	type BidComparisonProjectFile,
 	ProjectFilePicker,
 } from "../input/BidComparisonConfigDialog";
+import {
+	bidComparisonConfigToAttachments,
+	bidComparisonOutputFormat,
+	bidComparisonPrompt,
+	ensureBidComparisonFilesUploaded,
+} from "../input/bidComparisonAttachments";
 import type { AppNavigation } from "./LeftRail";
 import { ProjectTaskPickerField } from "./ProjectTaskPicker";
 
@@ -49,10 +59,11 @@ function payrollStarterPrompt(files: SelectedFile[]): string {
 	].join("\n");
 }
 
-export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation }) {
+export function WorkbenchPage({ navigation }: { navigation?: AppNavigation }) {
 	const { projects, fetchProjects, fetchTasks, sendWorkbenchMessage } = useLayoutStore((s) => s);
 	const { isAuthenticated, requireAuth } = useAuth();
 	const [dialogOpen, setDialogOpen] = useState(false);
+	const [bidComparisonOpen, setBidComparisonOpen] = useState(false);
 	const [projectId, setProjectId] = useState("");
 	const [taskId, setTaskId] = useState("");
 	const [files, setFiles] = useState<SelectedFile[]>([]);
@@ -72,6 +83,39 @@ export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation })
 			void fetchProjects();
 			setDialogOpen(true);
 		});
+	};
+
+	const openBidComparison = () => {
+		requireAuth(() => {
+			void fetchProjects();
+			setBidComparisonOpen(true);
+		});
+	};
+
+	const startBidComparison = async (config: BidComparisonConfig) => {
+		try {
+			const resolved = await ensureBidComparisonFilesUploaded(config, config.projectId);
+			const result = await sendWorkbenchMessage(
+				bidComparisonPrompt(resolved),
+				resolved.projectId,
+				"default",
+				bidComparisonConfigToAttachments(resolved),
+				undefined,
+				undefined,
+				undefined,
+				"bid_comparison",
+				bidComparisonOutputFormat(resolved),
+				resolved.taskId ?? null,
+			);
+			if (!result?.project_id || !result.task_id || !result.session_id) {
+				throw new Error("启动标书对比失败，请确认所选任务未在回复中后重试");
+			}
+			navigation?.goToTaskDetail(result.project_id, result.task_id, result.session_id);
+		} catch (error) {
+			console.error("WorkbenchPage start bid comparison error:", error);
+			toast.error(getRequestErrorMessage(error) ?? "启动标书对比失败");
+			throw error;
+		}
 	};
 
 	const resetDialog = () => {
@@ -168,17 +212,16 @@ export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation })
 		const role = filePickerRole;
 		setFiles((current) => {
 			const uploads = current.filter((file) => file.role === role && !file.publicId);
-			const projectFiles = selected
-				.map((file) => ({
-					id: `payroll-project-${file.publicId}`,
-					name: file.name,
-					publicId: file.publicId,
-					projectId: file.projectId,
-					storageUri: file.storageUri,
-					mimeType: file.mimeType,
-					size: file.size ?? 0,
-					role,
-				}));
+			const projectFiles = selected.map((file) => ({
+				id: `payroll-project-${file.publicId}`,
+				name: file.name,
+				publicId: file.publicId,
+				projectId: file.projectId,
+				storageUri: file.storageUri,
+				mimeType: file.mimeType,
+				size: file.size ?? 0,
+				role,
+			}));
 			return [...current.filter((file) => file.role !== role), ...uploads, ...projectFiles];
 		});
 		setFilePickerRole(null);
@@ -214,7 +257,7 @@ export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation })
 			resetDialog();
 			navigation?.goToTaskDetail(result.project_id, result.task_id, result.session_id);
 		} catch (error) {
-			console.error("PayrollWorkbench start analysis error:", error);
+			console.error("WorkbenchPage start analysis error:", error);
 			toast.error(error instanceof Error ? error.message : "启动工资核算分析失败");
 		} finally {
 			setSubmitting(false);
@@ -232,6 +275,25 @@ export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation })
 			<main className="flex min-h-0 flex-1 flex-col px-6 py-6">
 				<div className="w-full">
 					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+						<button
+							type="button"
+							onClick={openBidComparison}
+							className={cn(
+								"group flex min-h-[132px] cursor-pointer flex-col rounded-lg border border-slate-200 bg-white p-4",
+								"text-left transition-colors hover:border-[var(--leros-primary-soft)]",
+								"hover:bg-[var(--leros-primary-softer)]/35",
+							)}
+						>
+							<div className="flex size-10 items-center justify-center rounded-lg bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
+								<BidComparisonIcon className="size-5" />
+							</div>
+							<h3 className="mt-4 text-sm font-semibold text-[var(--leros-text-strong)]">
+								标书对比
+							</h3>
+							<p className="mt-1 text-xs leading-5 text-[var(--leros-text-muted)]">
+								选择投标文件与对比文件，发起标书对比分析任务。
+							</p>
+						</button>
 						<button
 							type="button"
 							onClick={openDialog}
@@ -308,9 +370,7 @@ export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation })
 												{title} <span className="text-red-500">*</span>
 											</div>
 										</div>
-										<span className="shrink-0 text-xs text-slate-400">
-											{roleFiles.length} 个
-										</span>
+										<span className="shrink-0 text-xs text-slate-400">{roleFiles.length} 个</span>
 									</div>
 									<div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/60 p-3">
 										{roleFiles.length ? (
@@ -451,6 +511,13 @@ export function PayrollWorkbench({ navigation }: { navigation?: AppNavigation })
 					) : null}
 				</DialogContent>
 			</Dialog>
+			<BidComparisonConfigDialog
+				open={bidComparisonOpen}
+				onOpenChange={setBidComparisonOpen}
+				onSave={startBidComparison}
+				onProjectChange={fetchTasks}
+				projects={projectOptions}
+			/>
 		</div>
 	);
 }

--- a/frontend/packages/app-ui/components/layout/index.ts
+++ b/frontend/packages/app-ui/components/layout/index.ts
@@ -1,12 +1,12 @@
 "use client";
 
 export { type AppNavigation, LeftRail } from "./LeftRail";
+export { NewTaskPage } from "./NewTaskPage";
 export { ProjectPage } from "./ProjectPage";
-export { PayrollWorkbench } from "./PayrollWorkbench";
 export { Shell } from "./Shell";
 export { TaskDetailPage } from "./TaskDetailPage";
-export { WorkbenchPanel } from "./WorkbenchPanel";
+export { WorkbenchPage } from "./WorkbenchPage";
 export {
-	buildAssistantWorkbenchPrefill,
-	buildSkillWorkbenchPrefill,
-} from "./workbench-prefill";
+	buildAssistantNewTaskPrefill,
+	buildSkillNewTaskPrefill,
+} from "./new-task-prefill";

--- a/frontend/packages/app-ui/components/layout/new-task-navigation.ts
+++ b/frontend/packages/app-ui/components/layout/new-task-navigation.ts
@@ -1,6 +1,6 @@
 import type { AppNavigation } from "./LeftRail";
 
-export function navigateToWorkbench(
+export function navigateToNewTask(
 	navigation: AppNavigation | undefined,
 	switchView: (view: "chat") => void,
 ) {

--- a/frontend/packages/app-ui/components/layout/new-task-prefill.test.ts
+++ b/frontend/packages/app-ui/components/layout/new-task-prefill.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildSkillWorkbenchPrefill } from "./workbench-prefill";
+import { buildSkillNewTaskPrefill } from "./new-task-prefill";
 
-describe("buildSkillWorkbenchPrefill", () => {
+describe("buildSkillNewTaskPrefill", () => {
 	it("uses the stable Skill code for the slash token", () => {
-		expect(buildSkillWorkbenchPrefill("demo-code")).toEqual({
+		expect(buildSkillNewTaskPrefill("demo-code")).toEqual({
 			value: "/demo-code ",
 			tokens: [
 				{
@@ -18,7 +18,7 @@ describe("buildSkillWorkbenchPrefill", () => {
 	});
 
 	it("uses the display name in content and keeps the Skill code on the token", () => {
-		expect(buildSkillWorkbenchPrefill("demo-code", undefined, "演示技能")).toEqual({
+		expect(buildSkillNewTaskPrefill("demo-code", undefined, "演示技能")).toEqual({
 			value: "/演示技能 ",
 			tokens: [
 				{
@@ -33,7 +33,7 @@ describe("buildSkillWorkbenchPrefill", () => {
 	});
 
 	it("keeps the optional prompt after the code token", () => {
-		expect(buildSkillWorkbenchPrefill("skill-creator", "请创建技能").value).toBe(
+		expect(buildSkillNewTaskPrefill("skill-creator", "请创建技能").value).toBe(
 			"/skill-creator 请创建技能",
 		);
 	});

--- a/frontend/packages/app-ui/components/layout/new-task-prefill.ts
+++ b/frontend/packages/app-ui/components/layout/new-task-prefill.ts
@@ -1,7 +1,7 @@
 import type { ComposerToken } from "@leros/store/types/chat";
 import { buildDefaultSummonPrompt } from "../digitalAssistant/promptSuggestions";
 
-export function buildSkillWorkbenchPrefill(
+export function buildSkillNewTaskPrefill(
 	code: string,
 	prompt?: string,
 	displayName?: string,
@@ -25,7 +25,7 @@ export function buildSkillWorkbenchPrefill(
 	};
 }
 
-export function buildAssistantWorkbenchPrefill(
+export function buildAssistantNewTaskPrefill(
 	assistantIdentity: string,
 	assistant: { name: string; expertise: string[]; source?: string },
 	prompt?: string,

--- a/frontend/packages/app-ui/components/skills/SkillMarketView.tsx
+++ b/frontend/packages/app-ui/components/skills/SkillMarketView.tsx
@@ -8,8 +8,8 @@ import { Import, Plus, Search } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../auth";
 import type { AppNavigation } from "../layout";
-import { navigateToWorkbench } from "../layout/workbench-navigation";
-import { buildSkillWorkbenchPrefill } from "../layout/workbench-prefill";
+import { navigateToNewTask } from "../layout/new-task-navigation";
+import { buildSkillNewTaskPrefill } from "../layout/new-task-prefill";
 import { useBrandIdentity } from "../private-deployment/useBrandIdentity";
 import { MarketplacePanel } from "./MarketplacePanel";
 import { McpConnectorPanel } from "./McpConnectorPanel";
@@ -52,11 +52,11 @@ export function SkillMarketView({ navigation }: { navigation?: AppNavigation }) 
 
 	const goUseSkill = useCallback(
 		(skillCode: string, displayName?: string): boolean => {
-			const prefill = buildSkillWorkbenchPrefill(skillCode, undefined, displayName);
+			const prefill = buildSkillNewTaskPrefill(skillCode, undefined, displayName);
 			selectWorkbenchProject(null);
 			selectWorkbenchTask(null);
 			setWorkbenchComposerPrefill(prefill);
-			navigateToWorkbench(navigation, switchView);
+			navigateToNewTask(navigation, switchView);
 			return true;
 		},
 		[
@@ -97,14 +97,14 @@ export function SkillMarketView({ navigation }: { navigation?: AppNavigation }) 
 
 	const openCreateSkill = useCallback(() => {
 		requireAuth(() => {
-			const prefill = buildSkillWorkbenchPrefill(
+			const prefill = buildSkillNewTaskPrefill(
 				"skill-creator",
 				"请创建一个用于「XXXXXX」的技能。",
 			);
 			selectWorkbenchProject(null);
 			selectWorkbenchTask(null);
 			setWorkbenchComposerPrefill(prefill);
-			navigateToWorkbench(navigation, switchView);
+			navigateToNewTask(navigation, switchView);
 		});
 	}, [
 		requireAuth,

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -787,7 +787,7 @@ export class LayoutActionImpl {
 			}
 		}
 
-		// 中文注释：CreateInitialMessage 失败需向上抛出，由 WorkbenchPanel toast 提示。
+		// 中文注释：CreateInitialMessage 失败需向上抛出，由 NewTaskPage toast 提示。
 		return await chat.sendProjectMessage(trimmed, workbenchProjectId, attachments, _metadata, {
 			assistantIds,
 			taskId: selectedTaskId,


### PR DESCRIPTION
- 新建任务、项目页、任务详情不再提供标书对比入口，只保留工作台卡片
- 工作台改为通用功能页，标书对比与考勤工资核算并列，标书对比排在前面
- 页面命名与路由对齐：工作台用 WorkbenchPage，新建任务用 NewTaskPage，避免再被当成工资专属页