### PR TITLE
feat(org): 按管理员角色控制组织管理权限并新增成员角色管理

### DIFF
--- a/backend/internal/adapter/account/auth_model.go
+++ b/backend/internal/adapter/account/auth_model.go
@@ -106,6 +106,7 @@ type AuthOrgInfo struct {
 	Name            string `json:"name"`
 	Logo            string `json:"logo,omitempty"`
 	IsDefault       bool   `json:"is_default,omitempty"`
+	IsAdmin         bool   `json:"is_admin,omitempty"`
 	CreatedByUin    uint   `json:"created_by_uin,omitempty"`
 	CreatedByUserID uint   `json:"created_by_user_id,omitempty"`
 	Uin             uint   `json:"uin,omitempty"`

--- a/backend/internal/adapter/account/enterprise/auth.go
+++ b/backend/internal/adapter/account/enterprise/auth.go
@@ -323,7 +323,7 @@ func (s *auth) AuthSession(ctx context.Context) (*account.AuthSessionOutput, err
 			Code:            resp.CompanyInfo.Alias,
 			Logo:            resp.CompanyInfo.Logo,
 			IsDefault:       true,
-			IsAdmin:         resp.EmployeeDetail.SysRole == "sys_admin",
+			IsAdmin:         resp.EmployeeDetail.SysRole == sysAdminRole,
 			CreatedByUin:    resp.CompanyInfo.CreatedByUin,
 			CreatedByUserID: resp.CompanyInfo.UserID,
 			UserName:        orgUinName,

--- a/backend/internal/adapter/account/enterprise/auth.go
+++ b/backend/internal/adapter/account/enterprise/auth.go
@@ -323,6 +323,7 @@ func (s *auth) AuthSession(ctx context.Context) (*account.AuthSessionOutput, err
 			Code:            resp.CompanyInfo.Alias,
 			Logo:            resp.CompanyInfo.Logo,
 			IsDefault:       true,
+			IsAdmin:         resp.EmployeeDetail.SysRole == "sys_admin",
 			CreatedByUin:    resp.CompanyInfo.CreatedByUin,
 			CreatedByUserID: resp.CompanyInfo.UserID,
 			UserName:        orgUinName,

--- a/backend/internal/adapter/account/enterprise/mapper.go
+++ b/backend/internal/adapter/account/enterprise/mapper.go
@@ -336,6 +336,7 @@ func mapUinListToAuthOrgInfos(uins []iamLoginUin) []account.AuthOrgInfo {
 			Name:            uin.CompanyName,
 			Logo:            uin.CompanyLogo,
 			Uin:             uin.Uin.ID,
+			IsAdmin:         uin.Role == "sys_admin",
 			CreatedByUin:    uin.CreatedByUin,
 			CreatedByUserID: uin.CreatedByUserID,
 			UserName:        uin.Uin.Name,

--- a/backend/internal/adapter/account/enterprise/mapper.go
+++ b/backend/internal/adapter/account/enterprise/mapper.go
@@ -336,7 +336,7 @@ func mapUinListToAuthOrgInfos(uins []iamLoginUin) []account.AuthOrgInfo {
 			Name:            uin.CompanyName,
 			Logo:            uin.CompanyLogo,
 			Uin:             uin.Uin.ID,
-			IsAdmin:         uin.Role == "sys_admin",
+			IsAdmin:         uin.Role == sysAdminRole,
 			CreatedByUin:    uin.CreatedByUin,
 			CreatedByUserID: uin.CreatedByUserID,
 			UserName:        uin.Uin.Name,

--- a/backend/internal/adapter/account/enterprise/mapper.go
+++ b/backend/internal/adapter/account/enterprise/mapper.go
@@ -364,6 +364,7 @@ func mapDepartmentTreeEmployeeToUserInfo(emp iamDepartmentTreeEmployee) account.
 		Email:     emp.Email,
 		Phone:     emp.Phone,
 		AvatarURL: emp.AvatarURL,
+		Role:      emp.Role,
 		CreatedAt: &emp.CreatedAt,
 	}
 }

--- a/backend/internal/adapter/account/enterprise/org_service.go
+++ b/backend/internal/adapter/account/enterprise/org_service.go
@@ -22,6 +22,9 @@ type org struct {
 	provisioning account.WorkerProvisioner
 }
 
+// sysAdminRole 表示 IAM 中拥有组织管理权限的系统角色。
+const sysAdminRole = "sys_admin"
+
 func NewOrg(database *gorm.DB, client *iamClient, provisioning account.WorkerProvisioner) *org {
 	return &org{db: database, client: client, provisioning: provisioning}
 }
@@ -198,10 +201,9 @@ func (s *org) ListOrgMembers(ctx context.Context, req *account.ListOrgMembersInp
 	}, nil
 }
 
-// IsOrgCreator 报告 uin 是否为 orgID 组织的创建者。
-// 企业版通过 IAM 的个人中心接口获取当前登录公司及其创建者 Uin，
-// 判定等价于"当前公司创建者 == uin"（orgID 为唯一鉴权组织）。
-// 其中 created_by_uin 由 IAM 侧反查公司 sys_admin 的企业 Uin 提供。
+// IsOrgCreator 报告当前登录用户是否拥有 orgID 组织的管理权限。
+// 企业版通过 IAM 的个人中心接口获取当前登录用户在公司的系统角色，
+// 角色为 sys_admin（与 AuthSession 的 is_admin 同源）即视为拥有组织管理权限。
 func (s *org) IsOrgCreator(ctx context.Context, orgID, uin uint) (bool, error) {
 	if orgID == 0 {
 		return false, nil
@@ -210,10 +212,7 @@ func (s *org) IsOrgCreator(ctx context.Context, orgID, uin uint) (bool, error) {
 	if err := s.client.callWithAuth(ctx, "account.DetailPersonalCenter", nil, &resp); err != nil {
 		return false, mapIAMError(err)
 	}
-	if resp.CompanyInfo.CreatedByUin == 0 {
-		return false, nil
-	}
-	return resp.CompanyInfo.CreatedByUin == uin, nil
+	return resp.EmployeeDetail.SysRole == sysAdminRole, nil
 }
 
 func (s *org) resolveOrgLogo(ctx context.Context, logoURL string) (string, error) {

--- a/backend/internal/adapter/account/enterprise/user_service.go
+++ b/backend/internal/adapter/account/enterprise/user_service.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/insmtx/Leros/backend/internal/adapter/account"
 	localauth "github.com/insmtx/Leros/backend/internal/api/auth"
@@ -24,6 +25,10 @@ func NewUser(client *iamClient, db *gorm.DB) *user {
 }
 
 func (s *user) CreateUser(ctx context.Context, req *account.CreateUserInput) (*account.CreateUserResponse, error) {
+	role := strings.TrimSpace(req.Role)
+	if role == "" {
+		role = "sys_employee"
+	}
 	var resp iamCreateDepartmentEmployeeResponseBody
 	if err := s.client.callWithAuth(ctx, "account.CreateDepartmentEmployee", &iamCreateDepartmentEmployeeReq{
 		UserName:      req.Name,
@@ -31,7 +36,7 @@ func (s *user) CreateUser(ctx context.Context, req *account.CreateUserInput) (*a
 		Email:         req.Email,
 		Phone:         req.Phone,
 		DepartmentIDs: req.DepartmentIDs,
-		Role:          "sys_employee",
+		Role:          role,
 	}, &resp); err != nil {
 		return nil, mapIAMError(err)
 	}
@@ -46,6 +51,7 @@ func (s *user) CreateUser(ctx context.Context, req *account.CreateUserInput) (*a
 		Name:   req.Name,
 		Email:  req.Email,
 		Phone:  req.Phone,
+		Role:   role,
 		IsNew:  true,
 	}, nil
 }
@@ -80,6 +86,9 @@ func (s *user) UpdateUser(ctx context.Context, publicID string, req *account.Upd
 		Uin:        target.Uin,
 		EmployeeID: target.EmployeeID,
 		Name:       req.Name,
+	}
+	if req.Role != nil {
+		editReq.Role = *req.Role
 	}
 	if req.Email != nil {
 		editReq.Email = *req.Email

--- a/backend/internal/adapter/account/user_model.go
+++ b/backend/internal/adapter/account/user_model.go
@@ -14,6 +14,7 @@ type UserInfo struct {
 	Email       string                `json:"email,omitempty"`
 	Phone       string                `json:"phone,omitempty"`
 	AvatarURL   string                `json:"avatar_url,omitempty"`
+	Role        string                `json:"role,omitempty"`
 	Departments []OrgMemberDepartment `json:"departments,omitempty"`
 	CreatedAt   *time.Time            `json:"created_at,omitempty"`
 	UpdatedAt   *time.Time            `json:"updated_at,omitempty"`
@@ -23,11 +24,13 @@ type CreateUserInput struct {
 	Phone         string `json:"phone"`
 	Email         string `json:"email"`
 	Name          string `json:"name"`
+	Role          string `json:"role,omitempty"`
 	DepartmentIDs []uint `json:"department_ids"`
 }
 
 type UpdateUserInput struct {
 	Name  string  `json:"name"`
+	Role  *string `json:"role,omitempty"`
 	Email *string `json:"email"`
 }
 
@@ -55,6 +58,7 @@ type CreateUserResponse struct {
 	Name   string `json:"name"`
 	Email  string `json:"email"`
 	Phone  string `json:"phone"`
+	Role   string `json:"role,omitempty"`
 	IsNew  bool   `json:"is_new"`
 }
 

--- a/backend/internal/api/handler/user_handler_enterprise_test.go
+++ b/backend/internal/api/handler/user_handler_enterprise_test.go
@@ -31,6 +31,7 @@ type storedUser struct {
 	Name  string
 	Email string
 	Phone string
+	Role  string
 }
 
 func newMockIAMServer() *mockIAMServer {
@@ -94,6 +95,7 @@ func (m *mockIAMServer) handleCreateEmployee(w http.ResponseWriter, raw json.Raw
 		Name     string `json:"name"`
 		Email    string `json:"email"`
 		Phone    string `json:"phone"`
+		Role     string `json:"role"`
 	}
 	json.Unmarshal(raw, &req)
 
@@ -114,7 +116,11 @@ func (m *mockIAMServer) handleCreateEmployee(w http.ResponseWriter, raw json.Raw
 
 	id := m.nextID
 	m.nextID++
-	m.users = append(m.users, storedUser{ID: id, Name: req.Name, Email: req.Email, Phone: req.Phone})
+	role := req.Role
+	if role == "" {
+		role = "member"
+	}
+	m.users = append(m.users, storedUser{ID: id, Name: req.Name, Email: req.Email, Phone: req.Phone, Role: role})
 
 	m.write(w, 0, map[string]any{
 		"employee": map[string]any{
@@ -125,7 +131,7 @@ func (m *mockIAMServer) handleCreateEmployee(w http.ResponseWriter, raw json.Raw
 			"phone":          req.Phone,
 			"employee_id":    id,
 			"user_id":        id,
-			"role":           "member",
+			"role":           role,
 			"department_ids": []int{},
 		},
 	})
@@ -221,6 +227,9 @@ func (m *mockIAMServer) handleEditDepartmentEmployee(w http.ResponseWriter, raw 
 	if req.Phone != "" {
 		found.Phone = req.Phone
 	}
+	if req.Role != "" {
+		found.Role = req.Role
+	}
 
 	m.write(w, 0, map[string]any{
 		"employee": map[string]any{
@@ -231,7 +240,7 @@ func (m *mockIAMServer) handleEditDepartmentEmployee(w http.ResponseWriter, raw 
 			"phone":          found.Phone,
 			"employee_id":    found.ID,
 			"user_id":        found.ID,
-			"role":           "member",
+			"role":           found.Role,
 			"department_ids": []int{},
 		},
 	})
@@ -259,7 +268,7 @@ func (m *mockIAMServer) handleListEmployee(w http.ResponseWriter, raw json.RawMe
 					"email":          u.Email,
 					"phone":          u.Phone,
 					"avatar_url":     "",
-					"sys_role":       "member",
+					"sys_role":       u.Role,
 					"department_ids": []int{},
 					"created_at":     "2024-01-01T00:00:00Z",
 				})
@@ -320,7 +329,7 @@ func (m *mockIAMServer) handleDepartmentTree(w http.ResponseWriter, raw json.Raw
 			"phone":          u.Phone,
 			"employee_id":    u.ID,
 			"user_id":        u.ID,
-			"role":           "member",
+			"role":           u.Role,
 			"department_ids": []int{},
 		})
 	}
@@ -615,4 +624,114 @@ func createEnterpriseUser(t *testing.T, router *gin.Engine, name string) createU
 		t.Fatalf("CreateUser expected code %d, got %d", dto.CodeSuccess, resp.Code)
 	}
 	return parseData[createUserResult](t, resp)
+}
+
+func TestEnterpriseCreateUser_DefaultRole(t *testing.T) {
+	mock := newMockIAMServer()
+	defer mock.close()
+	router := setupEnterpriseUserHandler(t, mock)
+
+	w := doRequest(t, router, "/CreateUser", `{"name":"张三"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateUser expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseResponse(t, w)
+	if resp.Code != dto.CodeSuccess {
+		t.Fatalf("expected code %d, got %d", dto.CodeSuccess, resp.Code)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.users) != 1 {
+		t.Fatalf("expected 1 stored user, got %d", len(mock.users))
+	}
+	if mock.users[0].Role != "sys_employee" {
+		t.Fatalf("expected IAM to receive default role sys_employee, got %q", mock.users[0].Role)
+	}
+}
+
+func TestEnterpriseCreateUser_WithAdminRole(t *testing.T) {
+	mock := newMockIAMServer()
+	defer mock.close()
+	router := setupEnterpriseUserHandler(t, mock)
+
+	w := doRequest(t, router, "/CreateUser", `{"name":"张三","role":"sys_admin"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateUser expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseResponse(t, w)
+	if resp.Code != dto.CodeSuccess {
+		t.Fatalf("expected code %d, got %d", dto.CodeSuccess, resp.Code)
+	}
+	result := parseData[createUserResult](t, resp)
+	if result.Role != "sys_admin" {
+		t.Fatalf("expected response role sys_admin, got %q", result.Role)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.users) != 1 {
+		t.Fatalf("expected 1 stored user, got %d", len(mock.users))
+	}
+	if mock.users[0].Role != "sys_admin" {
+		t.Fatalf("expected IAM to receive role sys_admin, got %q", mock.users[0].Role)
+	}
+}
+
+func TestEnterpriseListUser_PreservesRole(t *testing.T) {
+	mock := newMockIAMServer()
+	defer mock.close()
+	router := setupEnterpriseUserHandler(t, mock)
+
+	w := doRequest(t, router, "/CreateUser", `{"name":"张三","role":"sys_admin"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateUser expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	lw := doRequest(t, router, "/ListUser", `{}`)
+	if lw.Code != http.StatusOK {
+		t.Fatalf("ListUser expected 200, got %d: %s", lw.Code, lw.Body.String())
+	}
+	result := parseData[userListResult](t, parseResponse(t, lw))
+	if len(result.Items) < 1 {
+		t.Fatalf("expected at least 1 item, got %d", len(result.Items))
+	}
+	for _, item := range result.Items {
+		if item.Role != "sys_admin" {
+			t.Fatalf("expected item role sys_admin, got %q", item.Role)
+		}
+	}
+}
+
+func TestEnterpriseUpdateUser_ForwardsRole(t *testing.T) {
+	mock := newMockIAMServer()
+	defer mock.close()
+	router := setupEnterpriseUserHandler(t, mock)
+
+	createResult := createEnterpriseUser(t, router, "张三")
+
+	uw := doRequest(t, router, "/UpdateUser", fmt.Sprintf(`{"public_id":"%d","role":"sys_admin"}`, createResult.UserID))
+	if uw.Code != http.StatusOK {
+		t.Fatalf("UpdateUser expected 200, got %d: %s", uw.Code, uw.Body.String())
+	}
+	uresp := parseResponse(t, uw)
+	if uresp.Code != dto.CodeSuccess {
+		t.Fatalf("expected code %d, got %d", dto.CodeSuccess, uresp.Code)
+	}
+	updated := parseData[userInfo](t, uresp)
+	if updated.Role != "sys_admin" {
+		t.Fatalf("expected updated user role sys_admin, got %q", updated.Role)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	for _, u := range mock.users {
+		if u.ID == int(createResult.UserID) {
+			if u.Role != "sys_admin" {
+				t.Fatalf("expected stored user role sys_admin, got %q", u.Role)
+			}
+			return
+		}
+	}
+	t.Fatalf("stored user %d not found", createResult.UserID)
 }

--- a/backend/internal/api/handler/user_handler_test_helpers.go
+++ b/backend/internal/api/handler/user_handler_test_helpers.go
@@ -16,6 +16,7 @@ type userInfo struct {
 	Name     string `json:"name"`
 	Email    string `json:"email"`
 	Phone    string `json:"phone"`
+	Role     string `json:"role"`
 }
 
 type createUserResult struct {
@@ -23,6 +24,7 @@ type createUserResult struct {
 	Name   string `json:"name"`
 	Email  string `json:"email"`
 	Phone  string `json:"phone"`
+	Role   string `json:"role"`
 	IsNew  bool   `json:"is_new"`
 }
 

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -385,33 +385,24 @@ export function LeftRail({
 		resetProjectExpansionState();
 	}, [user?.currentOrg?.id, resetProjectExpansionState]);
 
-	// 中文注释：组织管理入口仅组织创建者可见；enterprise 用 createdByUserId，OSS 用 createdByUin。
+	// 中文注释：组织管理入口按 AuthSession 返回的 is_admin 判断，当前组织为管理员即可进入。
 	const currentOrgMeta =
 		user?.organizations?.find((org) => org.id === user?.currentOrg?.id) ?? user?.currentOrg;
-	const isOrgCreator = Boolean(
-		user &&
-			currentOrgMeta &&
-			((currentOrgMeta.createdByUserId != null &&
-				currentOrgMeta.createdByUserId !== 0 &&
-				user.userId === currentOrgMeta.createdByUserId) ||
-				(currentOrgMeta.createdByUin != null &&
-					currentOrgMeta.createdByUin !== 0 &&
-					user.uin === currentOrgMeta.createdByUin)),
-	);
+	const isOrgAdmin = Boolean(currentOrgMeta?.isAdmin);
 
 	const inOrgAdminMode = navigation
 		? isOrgAdminPath(navigation.currentPath)
 		: isOrgAdminView(currentView);
 
 	useEffect(() => {
-		// 中文注释：非创建者不应停留在组织管理页（含直达路由），自动回到新建任务首页。
-		if (isOrgCreator || !inOrgAdminMode) return;
+		// 中文注释：非管理员不应停留在组织管理页（含直达路由），自动回到新建任务首页。
+		if (isOrgAdmin || !inOrgAdminMode) return;
 		if (navigation) {
 			navigation.goToRoute("chat");
 			return;
 		}
 		switchView("chat");
-	}, [inOrgAdminMode, isOrgCreator, navigation, switchView]);
+	}, [inOrgAdminMode, isOrgAdmin, navigation, switchView]);
 
 	const handleNavClick = (item: NavItem) => {
 		const view = navIdToView[item.id] ?? "workbench";
@@ -426,7 +417,7 @@ export function LeftRail({
 	};
 
 	const handleOpenOrgAdmin = () => {
-		if (!isOrgCreator) return;
+		if (!isOrgAdmin) return;
 		requireAuth(() => {
 			if (navigation) {
 				navigation.goToRoute("orgProfile");
@@ -902,7 +893,7 @@ export function LeftRail({
 								<UserRound className="size-4 shrink-0" />
 								<span>账户管理</span>
 							</DropdownMenuItem>
-							{isOrgCreator ? (
+							{isOrgAdmin ? (
 								<DropdownMenuItem onClick={handleOpenOrgAdmin}>
 									<Building2 className="size-4 shrink-0" />
 									<span>组织管理</span>

--- a/frontend/packages/app-ui/components/org-admin/DepartmentTreePanel.tsx
+++ b/frontend/packages/app-ui/components/org-admin/DepartmentTreePanel.tsx
@@ -26,6 +26,7 @@ import {
 } from "@leros/ui/components/ui/dropdown-menu";
 import { Input } from "@leros/ui/components/ui/input";
 import { ScrollArea } from "@leros/ui/components/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@leros/ui/components/ui/select";
 import {
 	Table,
 	TableBody,
@@ -241,13 +242,10 @@ export function DepartmentTreePanel() {
 	const filteredTree = useMemo(() => filterDepartmentTree(tree, search), [tree, search]);
 	const departmentCount = useMemo(() => countDepartments(tree), [tree]);
 	const selectedDepartment = departments.find((item) => item.id === selectedId) ?? null;
-	// 中文注释：管理员判断优先取当前组织的 is_admin，兜底仍按创建人判断（旧会话兼容）。
-	const isDefaultUser =
-		user?.currentOrg?.isAdmin ??
-		user?.organizations?.find((org) => org.id === orgId)?.isAdmin ??
-		(user?.userId != null &&
-			(user?.userId === user?.currentOrg?.createdByUserId ||
-				user?.userId === user?.organizations?.find((org) => org.id === orgId)?.createdByUserId));
+	// 中文注释：组织管理权限由 AuthSession 返回的 is_admin（当前所查看组织，缺省回退到会话默认组织）决定。
+	const isDefaultUser = Boolean(
+		user?.organizations?.find((org) => org.id === orgId)?.isAdmin ?? user?.currentOrg?.isAdmin,
+	);
 
 	useEffect(() => {
 		// 中文注释：通讯录依赖组织创建人字段控制成员管理按钮，打开页面时刷新最新会话信息。
@@ -485,15 +483,17 @@ export function DepartmentTreePanel() {
 							{/* 中文注释：固定列比例并截断过长文本，避免表格最小内容宽度触发横向滚动。 */}
 							<Table className="table-fixed">
 								<colgroup>
-									<col className="w-[25%]" />
-									<col className="w-[25%]" />
-									<col className="w-[25%]" />
+									<col className="w-[20%]" />
+									<col className="w-[20%]" />
+									<col className="w-[15%]" />
+									<col className="w-[20%]" />
 									<col className="w-[25%]" />
 								</colgroup>
 								<TableHeader>
 									<TableRow>
 										<TableHead>用户名</TableHead>
 										<TableHead>{isPrivateDeployment ? "邮箱" : "手机号"}</TableHead>
+										<TableHead>角色</TableHead>
 										<TableHead>创建时间</TableHead>
 										<TableHead>操作</TableHead>
 									</TableRow>
@@ -505,21 +505,21 @@ export function DepartmentTreePanel() {
 												className="max-w-0 truncate font-medium"
 												title={member.name ?? "未命名"}
 											>
-												<span className="flex items-center gap-1.5">
-													{member.name ?? "未命名"}
-													{member.role === "sys_admin" ? (
-														<Badge variant="secondary" className="shrink-0">
-															管理员
-														</Badge>
-													) : (
-														<Badge variant="outline" className="shrink-0">
-															成员
-														</Badge>
-													)}
-												</span>
+												{member.name ?? "未命名"}
 											</TableCell>
 											<TableCell className="truncate">
 												{isPrivateDeployment ? member.email?.trim() || "-" : (member.phone ?? "-")}
+											</TableCell>
+											<TableCell className="whitespace-nowrap">
+												{member.role === "sys_admin" ? (
+													<Badge variant="secondary" className="shrink-0">
+														管理员
+													</Badge>
+												) : (
+													<Badge variant="outline" className="shrink-0">
+														成员
+													</Badge>
+												)}
 											</TableCell>
 											<TableCell className="truncate">
 												{formatMemberCreatedAt(member.created_at)}
@@ -808,24 +808,20 @@ function AddMemberDialog({
 
 					<div className="space-y-2">
 						<span className="text-sm font-medium text-[var(--leros-text-strong)]">角色</span>
-						<div className="flex gap-2">
-							<Button
-								type="button"
-								variant={role === "sys_employee" ? "default" : "outline"}
-								size="sm"
-								onClick={() => setRole("sys_employee")}
-							>
-								成员
-							</Button>
-							<Button
-								type="button"
-								variant={role === "sys_admin" ? "default" : "outline"}
-								size="sm"
-								onClick={() => setRole("sys_admin")}
-							>
-								管理员
-							</Button>
-						</div>
+						<Select
+							value={role}
+							onValueChange={(value) =>
+								setRole((value ?? "sys_employee") as "sys_admin" | "sys_employee")
+							}
+						>
+							<SelectTrigger size="sm" className="w-full" aria-label="选择角色">
+								<span>{role === "sys_admin" ? "管理员" : "成员"}</span>
+							</SelectTrigger>
+							<SelectContent align="end">
+								<SelectItem value="sys_employee">成员</SelectItem>
+								<SelectItem value="sys_admin">管理员</SelectItem>
+							</SelectContent>
+						</Select>
 						<p className="text-xs text-[var(--leros-text-subtle)]">
 							管理员可管理组织成员与部门，普通成员仅可浏览通讯录。
 						</p>
@@ -977,24 +973,20 @@ function EditUserDialog({ member, submitting, onClose, onSubmit }: EditUserDialo
 					</div>
 					<div className="space-y-2">
 						<span className="text-sm font-medium text-[var(--leros-text-strong)]">角色</span>
-						<div className="flex gap-2">
-							<Button
-								type="button"
-								variant={role === "sys_employee" ? "default" : "outline"}
-								size="sm"
-								onClick={() => setRole("sys_employee")}
-							>
-								成员
-							</Button>
-							<Button
-								type="button"
-								variant={role === "sys_admin" ? "default" : "outline"}
-								size="sm"
-								onClick={() => setRole("sys_admin")}
-							>
-								管理员
-							</Button>
-						</div>
+						<Select
+							value={role}
+							onValueChange={(value) =>
+								setRole((value ?? "sys_employee") as "sys_admin" | "sys_employee")
+							}
+						>
+							<SelectTrigger size="sm" className="w-full" aria-label="选择角色">
+								<span>{role === "sys_admin" ? "管理员" : "成员"}</span>
+							</SelectTrigger>
+							<SelectContent align="end">
+								<SelectItem value="sys_employee">成员</SelectItem>
+								<SelectItem value="sys_admin">管理员</SelectItem>
+							</SelectContent>
+						</Select>
 					</div>
 				</div>
 				<DialogFooter className="mt-6">

--- a/frontend/packages/app-ui/components/org-admin/DepartmentTreePanel.tsx
+++ b/frontend/packages/app-ui/components/org-admin/DepartmentTreePanel.tsx
@@ -241,11 +241,13 @@ export function DepartmentTreePanel() {
 	const filteredTree = useMemo(() => filterDepartmentTree(tree, search), [tree, search]);
 	const departmentCount = useMemo(() => countDepartments(tree), [tree]);
 	const selectedDepartment = departments.find((item) => item.id === selectedId) ?? null;
-	// 中文注释：当前组织对象未必携带创建人，优先从 AuthSession 的组织列表取对应组织的创建人。
-	const createdByUserId =
-		user?.organizations?.find((org) => org.id === orgId)?.createdByUserId ??
-		user?.currentOrg?.createdByUserId;
-	const isDefaultUser = user?.userId === createdByUserId;
+	// 中文注释：管理员判断优先取当前组织的 is_admin，兜底仍按创建人判断（旧会话兼容）。
+	const isDefaultUser =
+		user?.currentOrg?.isAdmin ??
+		user?.organizations?.find((org) => org.id === orgId)?.isAdmin ??
+		(user?.userId != null &&
+			(user?.userId === user?.currentOrg?.createdByUserId ||
+				user?.userId === user?.organizations?.find((org) => org.id === orgId)?.createdByUserId));
 
 	useEffect(() => {
 		// 中文注释：通讯录依赖组织创建人字段控制成员管理按钮，打开页面时刷新最新会话信息。
@@ -272,6 +274,7 @@ export function DepartmentTreePanel() {
 		phone: string,
 		email: string,
 		departmentIds: number[],
+		role: string,
 	) => {
 		if (!orgId) return;
 		setSubmitting(true);
@@ -283,6 +286,7 @@ export function DepartmentTreePanel() {
 				name: name.trim(),
 				phone: trimmedPhone || undefined,
 				email: trimmedEmail || undefined,
+				role: role || undefined,
 				department_ids: departmentIds,
 			});
 			toast.success("成员已添加");
@@ -296,7 +300,7 @@ export function DepartmentTreePanel() {
 		}
 	};
 
-	const handleUpdateMember = async (publicId: string, name: string) => {
+	const handleUpdateMember = async (publicId: string, name: string, role?: string) => {
 		if (!orgId) return;
 		const trimmedName = name.trim();
 		// 中文注释：编辑弹窗仍打开时可读到目标成员 uin，用于判断是否为当前登录用户本人。
@@ -306,6 +310,7 @@ export function DepartmentTreePanel() {
 			await orgAdminApi.updateUser({
 				public_id: publicId,
 				name: trimmedName,
+				role: role || undefined,
 			});
 			// 中文注释：通讯录改的是本人时，立即同步左下角展示名，与账户管理改名行为一致。
 			if (
@@ -500,7 +505,18 @@ export function DepartmentTreePanel() {
 												className="max-w-0 truncate font-medium"
 												title={member.name ?? "未命名"}
 											>
-												{member.name ?? "未命名"}
+												<span className="flex items-center gap-1.5">
+													{member.name ?? "未命名"}
+													{member.role === "sys_admin" ? (
+														<Badge variant="secondary" className="shrink-0">
+															管理员
+														</Badge>
+													) : (
+														<Badge variant="outline" className="shrink-0">
+															成员
+														</Badge>
+													)}
+												</span>
 											</TableCell>
 											<TableCell className="truncate">
 												{isPrivateDeployment ? member.email?.trim() || "-" : (member.phone ?? "-")}
@@ -618,7 +634,13 @@ type AddMemberDialogProps = {
 	orgName: string;
 	submitting: boolean;
 	onClose: () => void;
-	onSubmit: (name: string, phone: string, email: string, departmentIds: number[]) => void;
+	onSubmit: (
+		name: string,
+		phone: string,
+		email: string,
+		departmentIds: number[],
+		role: string,
+	) => void;
 };
 
 function AddMemberDialog({
@@ -636,6 +658,7 @@ function AddMemberDialog({
 		defaultDepartmentId ? [defaultDepartmentId] : [],
 	);
 	const [pickerOpen, setPickerOpen] = useState(false);
+	const [role, setRole] = useState<"sys_admin" | "sys_employee">("sys_employee");
 	const { shouldShowError, handleFieldBlur, touchField } = useFormFieldValidation();
 
 	const toggleDepartment = (id: number) => {
@@ -678,7 +701,7 @@ function AddMemberDialog({
 
 	const handleSubmit = () => {
 		if (!canSubmitMember) return;
-		onSubmit(trimmedName, trimmedPhone, trimmedEmail, selectedIds);
+		onSubmit(trimmedName, trimmedPhone, trimmedEmail, selectedIds, role);
 	};
 
 	return (
@@ -783,6 +806,31 @@ function AddMemberDialog({
 						</div>
 					)}
 
+					<div className="space-y-2">
+						<span className="text-sm font-medium text-[var(--leros-text-strong)]">角色</span>
+						<div className="flex gap-2">
+							<Button
+								type="button"
+								variant={role === "sys_employee" ? "default" : "outline"}
+								size="sm"
+								onClick={() => setRole("sys_employee")}
+							>
+								成员
+							</Button>
+							<Button
+								type="button"
+								variant={role === "sys_admin" ? "default" : "outline"}
+								size="sm"
+								onClick={() => setRole("sys_admin")}
+							>
+								管理员
+							</Button>
+						</div>
+						<p className="text-xs text-[var(--leros-text-subtle)]">
+							管理员可管理组织成员与部门，普通成员仅可浏览通讯录。
+						</p>
+					</div>
+
 					<FieldWithError error={showDepartmentError ? "请选择所属部门" : undefined}>
 						<div className="flex min-h-0 flex-1 flex-col gap-2">
 							<div className="flex items-center justify-between">
@@ -878,11 +926,14 @@ type EditUserDialogProps = {
 	member: User;
 	submitting: boolean;
 	onClose: () => void;
-	onSubmit: (publicId: string, name: string) => void;
+	onSubmit: (publicId: string, name: string, role?: string) => void;
 };
 
 function EditUserDialog({ member, submitting, onClose, onSubmit }: EditUserDialogProps) {
 	const [name, setName] = useState(member.name ?? "");
+	const [role, setRole] = useState<"sys_admin" | "sys_employee">(
+		(member.role as "sys_admin" | "sys_employee") ?? "sys_employee",
+	);
 
 	const handleSubmit = () => {
 		const trimmedName = name.trim();
@@ -890,7 +941,7 @@ function EditUserDialog({ member, submitting, onClose, onSubmit }: EditUserDialo
 			toast.error("用户名不能为空");
 			return;
 		}
-		onSubmit(member.public_id, trimmedName);
+		onSubmit(member.public_id, trimmedName, role);
 	};
 
 	return (
@@ -898,7 +949,7 @@ function EditUserDialog({ member, submitting, onClose, onSubmit }: EditUserDialo
 			<DialogContent className="w-[min(440px,95vw)] max-w-none">
 				<DialogHeader>
 					<DialogTitle>编辑成员</DialogTitle>
-					<DialogDescription>当前仅支持修改成员用户名，部门归属暂不支持编辑。</DialogDescription>
+					<DialogDescription>支持修改成员用户名与角色，部门归属暂不支持编辑。</DialogDescription>
 				</DialogHeader>
 				<div className="space-y-4">
 					<div className="space-y-2">
@@ -923,6 +974,27 @@ function EditUserDialog({ member, submitting, onClose, onSubmit }: EditUserDialo
 							value={isPrivateDeployment ? member.email?.trim() || "-" : (member.phone ?? "-")}
 							disabled
 						/>
+					</div>
+					<div className="space-y-2">
+						<span className="text-sm font-medium text-[var(--leros-text-strong)]">角色</span>
+						<div className="flex gap-2">
+							<Button
+								type="button"
+								variant={role === "sys_employee" ? "default" : "outline"}
+								size="sm"
+								onClick={() => setRole("sys_employee")}
+							>
+								成员
+							</Button>
+							<Button
+								type="button"
+								variant={role === "sys_admin" ? "default" : "outline"}
+								size="sm"
+								onClick={() => setRole("sys_admin")}
+							>
+								管理员
+							</Button>
+						</div>
 					</div>
 				</div>
 				<DialogFooter className="mt-6">

--- a/frontend/packages/app-ui/components/system-config/ModelManagementView.tsx
+++ b/frontend/packages/app-ui/components/system-config/ModelManagementView.tsx
@@ -27,7 +27,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@leros/ui/components/ui/table";
-import { Bot, Loader2, MoreHorizontal, Plus, Trash2, Wifi } from "lucide-react";
+import { AlertCircle, Bot, Loader2, MoreHorizontal, Plus, Trash2, Wifi } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ModelFormDialog } from "./ModelFormDialog";
@@ -37,8 +37,17 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 export function ModelManagementView() {
-	const { models, loading, loaded, fetchModels, deleteModel, setDefault, setStatus, testModel } =
-		useModelStore((s) => s);
+	const {
+		models,
+		loading,
+		loaded,
+		error,
+		fetchModels,
+		deleteModel,
+		setDefault,
+		setStatus,
+		testModel,
+	} = useModelStore((s) => s);
 	const [createOpen, setCreateOpen] = useState(false);
 	const [editTarget, setEditTarget] = useState<ModelItem | null>(null);
 	const [deleteTarget, setDeleteTarget] = useState<ModelItem | null>(null);
@@ -46,6 +55,7 @@ export function ModelManagementView() {
 	const [testingId, setTestingId] = useState<number | null>(null);
 
 	useEffect(() => {
+		// 中文注释：fetchModels 失败时 error 已写入 store，由下方错误态兜底展示。
 		void fetchModels();
 	}, [fetchModels]);
 
@@ -125,6 +135,14 @@ export function ModelManagementView() {
 					<div className="flex items-center justify-center py-20 text-sm text-slate-500">
 						<Loader2 className="mr-2 size-4 animate-spin" />
 						加载模型列表…
+					</div>
+				) : error && models.length === 0 ? (
+					<div className="flex flex-col items-center justify-center py-24 text-center">
+						<div className="flex size-16 items-center justify-center rounded-2xl border border-dashed border-slate-300 text-slate-400">
+							<AlertCircle className="size-8" strokeWidth={1.5} />
+						</div>
+						<p className="mt-6 text-xl font-semibold text-slate-900">模型列表加载失败</p>
+						<p className="mt-3 max-w-sm text-sm leading-6 text-slate-400">{error}</p>
 					</div>
 				) : models.length === 0 ? (
 					<div className="flex flex-col items-center justify-center py-24 text-center">

--- a/frontend/packages/store/api/authApi.ts
+++ b/frontend/packages/store/api/authApi.ts
@@ -77,6 +77,7 @@ export type AuthOrgInfo = {
 	name: string;
 	logo?: string;
 	is_default?: boolean;
+	is_admin?: boolean;
 	created_by_uin?: number;
 	created_by_user_id?: number;
 };

--- a/frontend/packages/store/api/orgAdminApi.ts
+++ b/frontend/packages/store/api/orgAdminApi.ts
@@ -40,6 +40,7 @@ export type User = {
 	phone?: string;
 	email?: string;
 	avatar_url?: string;
+	role?: string;
 	created_at?: string;
 	updated_at?: string;
 };
@@ -126,19 +127,22 @@ export const orgAdminApi = {
 		name: string;
 		phone?: string;
 		email?: string;
+		role?: string;
 		department_ids: number[];
 	}) =>
 		apiClient.post<BackendDataResponse<User>>(ENDPOINTS.createUser, {
 			name: params.name,
 			phone: params.phone,
 			email: params.email,
+			role: params.role,
 			department_ids: params.department_ids,
 		}),
 
-	updateUser: (params: { public_id: string; name?: string }) =>
+	updateUser: (params: { public_id: string; name?: string; role?: string }) =>
 		apiClient.post<BackendDataResponse<User>>(ENDPOINTS.updateUser, {
 			public_id: params.public_id,
 			name: params.name,
+			role: params.role,
 		}),
 
 	deleteUser: (params: { public_id: string }) =>

--- a/frontend/packages/store/slices/authSlice.test.ts
+++ b/frontend/packages/store/slices/authSlice.test.ts
@@ -92,4 +92,35 @@ describe("AuthActionImpl", () => {
 		expect(getState().authUser?.currentOrg?.id).toBe(2);
 		expect(getState().authUser?.currentOrg?.uin).toBe(20002);
 	});
+
+	it("setAuthSession 会话保留成员的 is_admin", async () => {
+		vi.spyOn(authApi, "authSession").mockResolvedValue({
+			data: {
+				code: 0,
+				message: "success",
+				data: {
+					user_info: {
+						id: 1,
+						public_id: "user-1",
+						name: "测试用户",
+						email: "test@example.com",
+					},
+					org: {
+						id: 2,
+						uin: 20002,
+						public_id: "org-2",
+						code: "org-2",
+						name: "AI冲锋队",
+						is_admin: true,
+					},
+					organizations: [],
+				},
+			},
+		} as never);
+		const { actions, getState } = createAuthActions();
+
+		await actions.refreshAuthSession();
+
+		expect(getState().authUser?.currentOrg?.isAdmin).toBe(true);
+	});
 });

--- a/frontend/packages/store/slices/authSlice.ts
+++ b/frontend/packages/store/slices/authSlice.ts
@@ -227,6 +227,7 @@ function toStoredAuthOrg(org: AuthOrgInfo): StoredAuthOrg {
 		name: org.name,
 		logo: org.logo,
 		isDefault: org.is_default,
+		isAdmin: org.is_admin,
 		createdByUin: org.created_by_uin,
 		createdByUserId: org.created_by_user_id,
 	};

--- a/frontend/packages/store/slices/modelSlice.ts
+++ b/frontend/packages/store/slices/modelSlice.ts
@@ -29,6 +29,8 @@ export type ModelState = {
 	total: number;
 	loading: boolean;
 	loaded: boolean;
+	/** 列表加载失败时的错误信息，null 表示无错误。 */
+	error: string | null;
 };
 
 export type ModelAction = Pick<ModelSliceImpl, keyof ModelSliceImpl>;
@@ -58,7 +60,13 @@ function mapBackendModel(m: BackendModel): ModelItem {
 	};
 }
 
-const _initialState: ModelState = { models: [], total: 0, loading: false, loaded: false };
+const _initialState: ModelState = {
+	models: [],
+	total: 0,
+	loading: false,
+	loaded: false,
+	error: null,
+};
 
 type SetState = (
 	partial:
@@ -86,9 +94,13 @@ export class ModelSliceImpl {
 				models: items.map(mapBackendModel),
 				total: res.data.data?.total ?? 0,
 				loaded: true,
+				error: null,
 			});
 		} catch (err) {
 			console.error("fetchModels error:", err);
+			this.#set({
+				error: err instanceof Error ? err.message : "加载模型列表失败",
+			});
 		} finally {
 			this.#set({ loading: false });
 		}
@@ -126,7 +138,7 @@ export class ModelSliceImpl {
 	testModel = (params: Parameters<typeof modelApi.test>[0]) => modelApi.test(params);
 
 	resetAuthScopedData = () => {
-		this.#set({ models: [], total: 0, loading: false, loaded: false });
+		this.#set({ models: [], total: 0, loading: false, loaded: false, error: null });
 	};
 }
 

--- a/frontend/packages/store/utils/authStorage.ts
+++ b/frontend/packages/store/utils/authStorage.ts
@@ -8,6 +8,7 @@ export type StoredAuthOrg = {
 	name: string;
 	logo?: string;
 	isDefault?: boolean;
+	isAdmin?: boolean;
 	createdByUin?: number;
 	createdByUserId?: number;
 };
@@ -51,6 +52,7 @@ type RefreshTokenPayload = {
 			name: string;
 			logo?: string;
 			is_default?: boolean;
+			is_admin?: boolean;
 			created_by_uin?: number;
 			created_by_user_id?: number;
 		};
@@ -62,6 +64,7 @@ type RefreshTokenPayload = {
 			name: string;
 			logo?: string;
 			is_default?: boolean;
+			is_admin?: boolean;
 			created_by_uin?: number;
 			created_by_user_id?: number;
 		}[];
@@ -234,6 +237,7 @@ function toStoredAuthOrg(org: {
 	name: string;
 	logo?: string;
 	is_default?: boolean;
+	is_admin?: boolean;
 	created_by_uin?: number;
 	created_by_user_id?: number;
 }): StoredAuthOrg {
@@ -245,6 +249,7 @@ function toStoredAuthOrg(org: {
 		name: org.name,
 		logo: org.logo,
 		isDefault: org.is_default,
+		isAdmin: org.is_admin,
 		createdByUin: org.created_by_uin,
 		createdByUserId: org.created_by_user_id,
 	};


### PR DESCRIPTION
## 背景

组织管理入口此前仅「组织创建者」可见/可操作，判定依赖 `createdByUserId`/`createdByUin` 与当前登录用户的比对。该判定在创建者离职或角色变更后会失效，且与实际权限模型（IAM 中的 `sys_admin` 系统角色）不一致。本 PR 将组织管理权限统一改为由登录态返回的 **`is_admin`**（enterprise 下与 `AuthSession` 同源，取 IAM 角色 `sys_admin`）决定，并补齐成员角色管理能力。

## 变更

**后端（enterprise account）**
- `AuthSession` / 组织列表透出当前用户在组织内的 `is_admin`（auth_model、user_model、auth.go、mapper.go）
- 创建/编辑组织成员时透传并保留角色（user_service.go、org_service.go），`sys_admin` 角色抽取为常量
- `IsOrgCreator` 语义改为「当前用户是否拥有组织管理权限」（以 IAM 角色判定），与 `is_admin` 同源
- 新增 enterprise 角色透传测试

**前端**
- 组织管理入口由 `isOrgCreator` 改为 `isOrgAdmin`（`currentOrg.isAdmin`），LeftRail、DepartmentTreePanel 同步调整
- 通讯录成员新增/编辑支持设置角色（下拉选择 成员/管理员），成员表格新增「角色」列
- `authSlice`/`authStorage` 增加 `is_admin` 字段存储与透传
- 模型管理页新增列表加载失败的错误兜底态（modelSlice 增加 `error` 字段）

## 验收

- 组织管理员（而非仅创建者）可进入组织管理并管理成员角色
- 成员角色在列表、编辑、会话鉴权三处保持一致
