### PR TITLE
fix(skill): 修复权限下载并避免准备失败阻塞任务

### DIFF
--- a/backend/internal/service/plugin_access.go
+++ b/backend/internal/service/plugin_access.go
@@ -227,14 +227,14 @@ func (s *pluginService) authorizeSkillDownload(
 	if actorUin == 0 {
 		return false, nil
 	}
-	role, err := s.pluginAccess().ResolveRole(ctx, orgID, actorUin, plugin)
+	err := s.pluginAccess().RequireUse(ctx, orgID, actorUin, plugin)
 	if err != nil {
-		if errors.Is(err, contract.ErrPluginNotFound) {
+		if errors.Is(err, contract.ErrPluginNotFound) || errors.Is(err, contract.ErrPluginForbidden) {
 			return false, nil
 		}
 		return false, err
 	}
-	return role != "", nil
+	return true, nil
 }
 
 // ensurePluginResourceOwner 幂等创建插件的活动权限资源与 owner 绑定。

--- a/backend/internal/service/plugin_service.go
+++ b/backend/internal/service/plugin_service.go
@@ -1142,10 +1142,12 @@ func (s *pluginService) ResolveSkillDownloadURLs(ctx context.Context, orgID uint
 		actorUin = callerID
 	}
 	var project *types.Project
-	if projectID := strings.TrimSpace(req.ProjectID); projectID != "" {
-		project, err = infradb.GetProjectByPublicID(ctx, s.db, orgID, projectID)
-		if err != nil {
-			return nil, err
+	if callerKind == types.CallerKindWorker {
+		if projectID := strings.TrimSpace(req.ProjectID); projectID != "" {
+			project, err = infradb.GetProjectByPublicID(ctx, s.db, orgID, projectID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	allowedCodes, err := s.downloadableSkillCodes(ctx, orgID, actorUin, project, codes)
@@ -1176,18 +1178,30 @@ func (s *pluginService) ResolveSkillDownloadURLs(ctx context.Context, orgID uint
 		}
 		existingCodes[row.Code] = true
 		if !allowedCodes[row.Code] {
+			logs.WarnContextf(
+				ctx,
+				"skip Skill download URL: permission denied code=%s caller_kind=%s actor_uin=%d project_id=%s",
+				row.Code, callerKind, actorUin, strings.TrimSpace(req.ProjectID),
+			)
 			continue
 		}
 		artifact, err := ArtifactFromDefinition("skill", row.Definition)
-		if err != nil || artifact == nil {
+		if err != nil {
+			logs.WarnContextf(ctx, "skip Skill download URL: invalid artifact definition code=%s error=%v", row.Code, err)
+			continue
+		}
+		if artifact == nil {
+			logs.WarnContextf(ctx, "skip Skill download URL: missing artifact definition code=%s", row.Code)
 			continue
 		}
 		sha, err := normalizedPluginSHA256(artifact.SHA256)
 		if err != nil {
+			logs.WarnContextf(ctx, "skip Skill download URL: invalid artifact SHA-256 code=%s error=%v", row.Code, err)
 			continue
 		}
 		downloadURL, err := s.resolveSkillArtifactDownloadURL(ctx, orgID, row, artifact, sha)
 		if err != nil {
+			logs.WarnContextf(ctx, "skip Skill download URL: artifact unavailable code=%s error=%v", row.Code, err)
 			continue
 		}
 		result = append(result, contract.SkillDownloadURL{Code: row.Code, Revision: row.Revision, SHA256: sha, DownloadURL: downloadURL})

--- a/backend/internal/service/plugin_service_test.go
+++ b/backend/internal/service/plugin_service_test.go
@@ -1283,6 +1283,101 @@ func TestOrganizationSkillDownloadResolvesCurrentRevisionByCode(t *testing.T) {
 	}
 }
 
+func TestPrivateSkillDownloadAllowsUseRolesAndProjectBinding(t *testing.T) {
+	database := setupPluginServiceTestDB(t)
+	setupPluginServiceTestStorage(t)
+	ctx := context.Background()
+	_, definition := uploadPluginServiceSkillArtifact(t, database, 7, 8, "private-download", "private Skill")
+	plugin := &types.Plugin{
+		PublicID:        "plugin_private_download",
+		OwnerScope:      types.OwnerScopeOrganization,
+		OrgID:           7,
+		Code:            "private-download",
+		Kind:            "skill",
+		Name:            "Private Download",
+		Visibility:      types.PluginVisibilityPrivate,
+		Status:          types.PluginStatusActive,
+		Origin:          "org",
+		CurrentRevision: 1,
+		CreatedBy:       8,
+		UpdatedBy:       8,
+	}
+	if err := database.Create(plugin).Error; err != nil {
+		t.Fatalf("create private plugin: %v", err)
+	}
+	seedPluginResourceOwner(t, database, 7, plugin.ID, 8)
+	if err := database.Create(&types.PluginRevision{
+		PluginID: plugin.ID, Revision: 1, Status: "published", Definition: definition,
+		PublishedByType: "user", PublishedByID: 8, PublishedAt: time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create private revision: %v", err)
+	}
+
+	var resource types.Resource
+	if err := database.Where(
+		"org_id = ? AND type = ? AND biz_id = ?", 7, types.ResourceTypePlugin, plugin.ID,
+	).First(&resource).Error; err != nil {
+		t.Fatalf("load private plugin resource: %v", err)
+	}
+	for _, item := range []struct {
+		uin  uint
+		role types.ResourceRole
+	}{
+		{uin: 9, role: types.ResourceRoleAdmin},
+		{uin: 10, role: types.ResourceRoleViewer},
+	} {
+		uin := item.uin
+		if err := database.Create(&types.ResourceBinding{OrgID: 7, Uin: &uin, ResourceID: resource.ID, Role: item.role}).Error; err != nil {
+			t.Fatalf("create %s binding: %v", item.role, err)
+		}
+	}
+
+	service := &pluginService{db: database}
+	for _, uin := range []uint{8, 9, 10} {
+		resolved, err := service.ResolveSkillDownloadURLs(ctx, 7, types.CallerKindWorker, 99, &contract.ResolveSkillDownloadURLsRequest{
+			SkillCodes: []string{plugin.Code}, ActorUin: uin,
+		})
+		if err != nil || len(resolved.Skills) != 1 || resolved.Skills[0].DownloadURL == "" {
+			t.Fatalf("use role %d resolution = %#v, %v", uin, resolved, err)
+		}
+		userResolved, err := service.ResolveSkillDownloadURLs(ctx, 7, types.CallerKindUser, uin, &contract.ResolveSkillDownloadURLsRequest{
+			SkillCodes: []string{plugin.Code}, ActorUin: 11,
+		})
+		if err != nil || len(userResolved.Skills) != 1 || userResolved.Skills[0].DownloadURL == "" {
+			t.Fatalf("user use role %d resolution = %#v, %v", uin, userResolved, err)
+		}
+	}
+
+	denied, err := service.ResolveSkillDownloadURLs(ctx, 7, types.CallerKindWorker, 99, &contract.ResolveSkillDownloadURLsRequest{
+		SkillCodes: []string{plugin.Code}, ActorUin: 11,
+	})
+	if err != nil || len(denied.Skills) != 0 {
+		t.Fatalf("unprivileged resolution = %#v, %v", denied, err)
+	}
+
+	project := &types.Project{PublicID: "project_private_download", OrgID: 7, OwnerID: 8, Name: "Private Download"}
+	if err := database.Create(project).Error; err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if err := database.Create(&types.ProjectPluginBinding{
+		ProjectID: project.ID, PluginID: plugin.ID, Enabled: true, Config: []byte(`{}`), CreatedBy: 8, UpdatedBy: 8,
+	}).Error; err != nil {
+		t.Fatalf("bind private plugin to project: %v", err)
+	}
+	projectResolved, err := service.ResolveSkillDownloadURLs(ctx, 7, types.CallerKindWorker, 99, &contract.ResolveSkillDownloadURLsRequest{
+		SkillCodes: []string{plugin.Code}, ActorUin: 11, ProjectID: project.PublicID,
+	})
+	if err != nil || len(projectResolved.Skills) != 1 {
+		t.Fatalf("project-bound resolution = %#v, %v", projectResolved, err)
+	}
+	userProjectResolved, err := service.ResolveSkillDownloadURLs(ctx, 7, types.CallerKindUser, 11, &contract.ResolveSkillDownloadURLsRequest{
+		SkillCodes: []string{plugin.Code}, ActorUin: 8, ProjectID: project.PublicID,
+	})
+	if err != nil || len(userProjectResolved.Skills) != 0 {
+		t.Fatalf("user project authorization bypass = %#v, %v", userProjectResolved, err)
+	}
+}
+
 func TestSkillDownloadURLsAutoInstallsMarketplaceSkillOnlyForWorker(t *testing.T) {
 	database := setupPluginServiceTestDB(t)
 	setupPluginServiceTestStorage(t)

--- a/backend/internal/worker/agentrun/skill_preparer.go
+++ b/backend/internal/worker/agentrun/skill_preparer.go
@@ -73,6 +73,13 @@ type connectorSkillDownloadRef struct {
 	Revision int    `json:"revision"`
 }
 
+// skillDownloadContext carries the trusted run identity needed by the server
+// to authorize private Skill downloads without treating the Worker as owner.
+type skillDownloadContext struct {
+	ActorUIN  uint
+	ProjectID string
+}
+
 type pluginSkillDescriptor struct {
 	Code         string
 	Revision     int
@@ -105,10 +112,15 @@ func (p *PluginSkillPreparer) PrepareSkills(ctx context.Context, req *agentrundo
 	if req == nil {
 		return "", func() {}, fmt.Errorf("run request is required")
 	}
+	downloadContext := skillDownloadContext{
+		ActorUIN:  req.BusinessKeys.UinPK,
+		ProjectID: strings.TrimSpace(req.Workspace.ProjectID),
+	}
 	policy := applyDisabledPluginPolicy(ctx, req)
 	viewRoot, err := taskSkillViewRoot(workspace)
 	if err != nil {
-		return "", func() {}, err
+		logs.WarnContextf(ctx, "resolve task Skill directory failed; continuing without run Skill view: error=%v", err)
+		return "", func() {}, nil
 	}
 	cleanup := func() {
 		importTaskSkillDirs(ctx, p.baselineCommitter, viewRoot)
@@ -123,12 +135,12 @@ func (p *PluginSkillPreparer) PrepareSkills(ctx context.Context, req *agentrundo
 	if err := linkSkillChildren(systemSkillsDir(), viewRoot, policy); err != nil {
 		logs.WarnContextf(ctx, "link worker system Skills failed; continuing: root=%s error=%v", viewRoot, err)
 	}
-	p.preparePluginSkills(ctx, req.Plugins, viewRoot, policy)
-	if err := p.prepareSceneSkills(ctx, req, viewRoot); err != nil {
-		return "", cleanup, fmt.Errorf("prepare scene skills: %w", err)
+	p.preparePluginSkills(ctx, req.Plugins, viewRoot, policy, downloadContext)
+	if err := p.prepareSceneSkills(ctx, req, viewRoot, downloadContext); err != nil {
+		logs.WarnContextf(ctx, "prepare scene Skills failed; continuing without failed Skills: error=%v", err)
 	}
-	if err := p.prepareInvokedSkills(ctx, req.Input.Messages, viewRoot, policy); err != nil {
-		return "", cleanup, fmt.Errorf("prepare invoked skills: %w", err)
+	if err := p.prepareInvokedSkills(ctx, req.Input.Messages, viewRoot, policy, downloadContext); err != nil {
+		logs.WarnContextf(ctx, "prepare invoked Skills failed; continuing without failed Skills: error=%v", err)
 	}
 	return viewRoot, cleanup, nil
 }
@@ -137,6 +149,7 @@ func (p *PluginSkillPreparer) prepareSceneSkills(
 	ctx context.Context,
 	req *agentrundomain.RunRequest,
 	viewRoot string,
+	downloadContext skillDownloadContext,
 ) error {
 	if req == nil || !strings.EqualFold(strings.TrimSpace(req.Input.Scene), salaryAccountingScene) {
 		return nil
@@ -144,7 +157,7 @@ func (p *PluginSkillPreparer) prepareSceneSkills(
 	const code = "attendance-payroll"
 	// 场景 Skill 包含会随代码一起演进的确定性计算器。不能因为任务视图
 	// 已经存在旧副本就跳过刷新，否则工资规则修复不会进入本次运行。
-	if err := p.installLatestSkills(ctx, []string{code}, viewRoot, salaryAccountingScene); err != nil {
+	if err := p.installLatestSkills(ctx, []string{code}, viewRoot, salaryAccountingScene, downloadContext); err != nil {
 		return err
 	}
 	logs.InfoContextf(ctx, "installed scene Skill %q for scene=%s", code, salaryAccountingScene)
@@ -156,6 +169,7 @@ func (p *PluginSkillPreparer) preparePluginSkills(
 	snapshots []agentrundomain.PluginSnapshot,
 	viewRoot string,
 	policy disabledPluginPolicy,
+	downloadContext skillDownloadContext,
 ) {
 	skillsRoot, err := leros.JoinWorkspace(".leros", "skills")
 	if err != nil {
@@ -244,7 +258,7 @@ func (p *PluginSkillPreparer) preparePluginSkills(
 			standardCodes = append(standardCodes, code)
 		}
 		sort.Strings(standardCodes)
-		downloads, err := p.resolveDownloadURLs(ctx, standardCodes, connectorRefs, "")
+		downloads, err := p.resolveDownloadURLs(ctx, standardCodes, connectorRefs, "", downloadContext)
 		if err != nil {
 			logs.WarnContextf(ctx, "resolve project Skill download URLs failed: %v", err)
 		} else {
@@ -296,7 +310,13 @@ func (p *PluginSkillPreparer) preparePluginSkills(
 
 // prepareInvokedSkills installs the latest organization Skill when an explicit
 // invocation is not actually available in the prepared run view.
-func (p *PluginSkillPreparer) prepareInvokedSkills(ctx context.Context, messages []agentrundomain.InputMessage, viewRoot string, policy disabledPluginPolicy) error {
+func (p *PluginSkillPreparer) prepareInvokedSkills(
+	ctx context.Context,
+	messages []agentrundomain.InputMessage,
+	viewRoot string,
+	policy disabledPluginPolicy,
+	downloadContext skillDownloadContext,
+) error {
 	missing := make(map[string]struct{})
 	for _, message := range messages {
 		if message.Role != "user" {
@@ -330,14 +350,19 @@ func (p *PluginSkillPreparer) prepareInvokedSkills(ctx context.Context, messages
 		codes = append(codes, code)
 	}
 	sort.Strings(codes)
-	return p.installLatestSkills(ctx, codes, viewRoot, "")
+	return p.installLatestSkills(ctx, codes, viewRoot, "", downloadContext)
 }
 
 func isSystemSkill(code string) bool {
 	return hasSkillDocument(filepath.Join(systemSkillsDir(), code))
 }
 
-func (p *PluginSkillPreparer) installLatestSkills(ctx context.Context, codes []string, viewRoot, scene string) error {
+func (p *PluginSkillPreparer) installLatestSkills(
+	ctx context.Context,
+	codes []string,
+	viewRoot, scene string,
+	downloadContext skillDownloadContext,
+) error {
 	skillsRoot, err := leros.JoinWorkspace(".leros", "skills")
 	if err != nil {
 		return fmt.Errorf("resolve worker Skill directory: %w", err)
@@ -353,7 +378,7 @@ func (p *PluginSkillPreparer) installLatestSkills(ctx context.Context, codes []s
 	if err != nil {
 		return fmt.Errorf("read worker Skill install manifest: %w", err)
 	}
-	downloads, err := p.resolveDownloadURLs(ctx, codes, nil, scene)
+	downloads, err := p.resolveDownloadURLs(ctx, codes, nil, scene, downloadContext)
 	if err != nil {
 		return fmt.Errorf("resolve download URLs: %w", err)
 	}
@@ -430,6 +455,7 @@ func (p *PluginSkillPreparer) resolveDownloadURLs(
 	codes []string,
 	connectorRefs []connectorSkillDownloadRef,
 	scene string,
+	downloadContext skillDownloadContext,
 ) (map[string]skillDownloadURLResponse, error) {
 	if p == nil || strings.TrimSpace(p.serverAddr) == "" {
 		return nil, fmt.Errorf("server address is required")
@@ -438,7 +464,15 @@ func (p *PluginSkillPreparer) resolveDownloadURLs(
 		SkillCodes      []string                    `json:"skill_codes"`
 		ConnectorSkills []connectorSkillDownloadRef `json:"connector_skills,omitempty"`
 		Scene           string                      `json:"scene,omitempty"`
-	}{SkillCodes: codes, ConnectorSkills: connectorRefs, Scene: scene})
+		ActorUIN        uint                        `json:"actor_uin,omitempty"`
+		ProjectID       string                      `json:"project_id,omitempty"`
+	}{
+		SkillCodes:      codes,
+		ConnectorSkills: connectorRefs,
+		Scene:           scene,
+		ActorUIN:        downloadContext.ActorUIN,
+		ProjectID:       downloadContext.ProjectID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("encode skill download URL request: %w", err)
 	}

--- a/backend/internal/worker/agentrun/skill_preparer_test.go
+++ b/backend/internal/worker/agentrun/skill_preparer_test.go
@@ -257,6 +257,16 @@ func TestPluginSkillPreparerInstallsSkillAtWorkerRootAndRefreshesIt(t *testing.T
 			if got := request.Header.Get("Authorization"); got != "Bearer worker-token" {
 				t.Fatalf("download URL authorization = %q", got)
 			}
+			var payload struct {
+				ActorUIN  uint   `json:"actor_uin"`
+				ProjectID string `json:"project_id"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.ActorUIN != 31 || payload.ProjectID != "project-xlsx" {
+				t.Fatalf("download authorization context = actor_uin:%d project_id:%q", payload.ActorUIN, payload.ProjectID)
+			}
 			downloadURLRequests++
 			packages := [][]byte{firstPackage, secondPackage}
 			if downloadURLRequests > len(packages) {
@@ -277,7 +287,12 @@ func TestPluginSkillPreparerInstallsSkillAtWorkerRootAndRefreshesIt(t *testing.T
 	defer server.Close()
 	baseline := &skillBaselineCommitterStub{}
 	preparer := NewPluginSkillPreparerWithBaseline(server.URL, "worker-token", baseline)
-	firstRequest := &agentrundomain.RunRequest{RunID: "run-one", Plugins: []agentrundomain.PluginSnapshot{testPluginSkillSnapshot("xlsx", 1, firstPackage)}}
+	firstRequest := &agentrundomain.RunRequest{
+		RunID:        "run-one",
+		Workspace:    agentrundomain.WorkspaceContext{ProjectID: "project-xlsx"},
+		BusinessKeys: agentrundomain.BusinessKeys{UinPK: 31},
+		Plugins:      []agentrundomain.PluginSnapshot{testPluginSkillSnapshot("xlsx", 1, firstPackage)},
+	}
 	firstView, firstCleanup, err := preparer.PrepareSkills(context.Background(), firstRequest, WorkspacePreparation{TaskDir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("install first skill: %v", err)
@@ -296,7 +311,13 @@ func TestPluginSkillPreparerInstallsSkillAtWorkerRootAndRefreshesIt(t *testing.T
 		t.Fatalf("legacy plugin cache must not be created, err=%v", err)
 	}
 
-	_, secondCleanup, err := preparer.PrepareSkills(context.Background(), &agentrundomain.RunRequest{RunID: "run-two", Plugins: firstRequest.Plugins, Input: agentrundomain.InputContext{Messages: []agentrundomain.InputMessage{{Role: "user", Content: "/xlsx reuse project Skill"}}}}, WorkspacePreparation{TaskDir: t.TempDir()})
+	_, secondCleanup, err := preparer.PrepareSkills(context.Background(), &agentrundomain.RunRequest{
+		RunID:        "run-two",
+		Workspace:    agentrundomain.WorkspaceContext{ProjectID: "project-xlsx"},
+		BusinessKeys: agentrundomain.BusinessKeys{UinPK: 31},
+		Plugins:      firstRequest.Plugins,
+		Input:        agentrundomain.InputContext{Messages: []agentrundomain.InputMessage{{Role: "user", Content: "/xlsx reuse project Skill"}}},
+	}, WorkspacePreparation{TaskDir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("reuse installed skill: %v", err)
 	}
@@ -305,7 +326,12 @@ func TestPluginSkillPreparerInstallsSkillAtWorkerRootAndRefreshesIt(t *testing.T
 		t.Fatalf("expected matching install to skip requests, urls=%d downloads=%d", downloadURLRequests, packageDownloads)
 	}
 
-	_, thirdCleanup, err := preparer.PrepareSkills(context.Background(), &agentrundomain.RunRequest{RunID: "run-three", Plugins: []agentrundomain.PluginSnapshot{testPluginSkillSnapshot("xlsx", 2, secondPackage)}}, WorkspacePreparation{TaskDir: t.TempDir()})
+	_, thirdCleanup, err := preparer.PrepareSkills(context.Background(), &agentrundomain.RunRequest{
+		RunID:        "run-three",
+		Workspace:    agentrundomain.WorkspaceContext{ProjectID: "project-xlsx"},
+		BusinessKeys: agentrundomain.BusinessKeys{UinPK: 31},
+		Plugins:      []agentrundomain.PluginSnapshot{testPluginSkillSnapshot("xlsx", 2, secondPackage)},
+	}, WorkspacePreparation{TaskDir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("update installed skill: %v", err)
 	}
@@ -697,12 +723,17 @@ func TestPluginSkillPreparerFetchesMissingInvokedSkill(t *testing.T) {
 			requests++
 			var body struct {
 				SkillCodes []string `json:"skill_codes"`
+				ActorUIN   uint     `json:"actor_uin"`
+				ProjectID  string   `json:"project_id"`
 			}
 			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
 			if len(body.SkillCodes) != 1 || body.SkillCodes[0] != "docx" {
 				t.Fatalf("requested Skill codes = %#v", body.SkillCodes)
+			}
+			if body.ActorUIN != 42 || body.ProjectID != "project-invoked" {
+				t.Fatalf("download authorization context = actor_uin:%d project_id:%q", body.ActorUIN, body.ProjectID)
 			}
 			_ = json.NewEncoder(writer).Encode(map[string]any{"code": 0, "data": map[string]any{"skills": []map[string]any{{"code": "docx", "revision": 3, "sha256": testPackageHash(packageBytes), "download_url": server.URL + "/package"}}}})
 		case "/package":
@@ -714,7 +745,14 @@ func TestPluginSkillPreparerFetchesMissingInvokedSkill(t *testing.T) {
 	defer server.Close()
 	prepared, cleanup, err := NewPluginSkillPreparer(server.URL, "worker-token").PrepareSkills(
 		context.Background(),
-		&agentrundomain.RunRequest{RunID: "run-invoked", Input: agentrundomain.InputContext{Messages: []agentrundomain.InputMessage{{Role: "user", Content: `<skill-chip data-code="docx">docx</skill-chip> create a report`}}}},
+		&agentrundomain.RunRequest{
+			RunID:        "run-invoked",
+			Workspace:    agentrundomain.WorkspaceContext{ProjectID: "project-invoked"},
+			BusinessKeys: agentrundomain.BusinessKeys{UinPK: 42},
+			Input: agentrundomain.InputContext{Messages: []agentrundomain.InputMessage{
+				{Role: "user", Content: `<skill-chip data-code="docx">docx</skill-chip> create a report`},
+			}},
+		},
 		WorkspacePreparation{TaskDir: t.TempDir()},
 	)
 	defer cleanup()
@@ -794,7 +832,7 @@ func TestPluginSkillPreparerRetriesInvokedProjectSkillAfterProjectPreparationFai
 	}
 }
 
-func TestPluginSkillPreparerReturnsInvokedSkillPreparationError(t *testing.T) {
+func TestPluginSkillPreparerSkipsUnavailableInvokedSkillWithoutFailingRun(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	t.Setenv(leros.EnvWorkspaceRoot, workspaceRoot)
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -808,7 +846,7 @@ func TestPluginSkillPreparerReturnsInvokedSkillPreparationError(t *testing.T) {
 		})
 	}))
 	defer server.Close()
-	_, cleanup, err := NewPluginSkillPreparer(server.URL, "worker-token").PrepareSkills(
+	prepared, cleanup, err := NewPluginSkillPreparer(server.URL, "worker-token").PrepareSkills(
 		context.Background(),
 		&agentrundomain.RunRequest{
 			RunID: "run-missing-invoked",
@@ -819,8 +857,73 @@ func TestPluginSkillPreparerReturnsInvokedSkillPreparationError(t *testing.T) {
 		WorkspacePreparation{TaskDir: t.TempDir()},
 	)
 	defer cleanup()
-	if err == nil || !strings.Contains(err.Error(), `Skill "missing": server returned no download URL`) {
-		t.Fatalf("explicit Skill error = %v", err)
+	if err != nil {
+		t.Fatalf("unavailable invoked Skill must not fail run preparation: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(prepared, "missing")); !os.IsNotExist(err) {
+		t.Fatalf("unavailable invoked Skill must not create run link, err=%v", err)
+	}
+}
+
+func TestPluginSkillPreparerSkipsUnavailableSceneSkillWithoutFailingRun(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	t.Setenv(leros.EnvWorkspaceRoot, workspaceRoot)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/plugins/skills/download-urls" {
+			http.NotFound(writer, request)
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(map[string]any{
+			"code": 0,
+			"data": map[string]any{"skills": []any{}},
+		})
+	}))
+	defer server.Close()
+	prepared, cleanup, err := NewPluginSkillPreparer(server.URL, "worker-token").PrepareSkills(
+		context.Background(),
+		&agentrundomain.RunRequest{
+			RunID:        "run-unavailable-scene",
+			BusinessKeys: agentrundomain.BusinessKeys{UinPK: 42},
+			Input:        agentrundomain.InputContext{Scene: salaryAccountingScene},
+		},
+		WorkspacePreparation{TaskDir: t.TempDir()},
+	)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("unavailable scene Skill must not fail run preparation: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(prepared, "attendance-payroll")); !os.IsNotExist(err) {
+		t.Fatalf("unavailable scene Skill must not create run link, err=%v", err)
+	}
+}
+
+func TestPluginSkillPreparerSkipsDownloadRequestFailureWithoutFailingRun(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	t.Setenv(leros.EnvWorkspaceRoot, workspaceRoot)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/v1/plugins/skills/download-urls" {
+			http.Error(writer, "temporary failure", http.StatusServiceUnavailable)
+			return
+		}
+		http.NotFound(writer, request)
+	}))
+	defer server.Close()
+	prepared, cleanup, err := NewPluginSkillPreparer(server.URL, "worker-token").PrepareSkills(
+		context.Background(),
+		&agentrundomain.RunRequest{
+			RunID: "run-download-failure",
+			Input: agentrundomain.InputContext{
+				Messages: []agentrundomain.InputMessage{{Role: "user", Content: `<skill-chip data-code="query-time">query-time</skill-chip> query`}},
+			},
+		},
+		WorkspacePreparation{TaskDir: t.TempDir()},
+	)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("download request failure must not fail run preparation: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(prepared, "query-time")); !os.IsNotExist(err) {
+		t.Fatalf("download request failure must not create run link, err=%v", err)
 	}
 }
 


### PR DESCRIPTION
- Worker 下载 Skill 时传递实际运行用户 `actor_uin` 和项目 `project_id`。
- 服务端按 `plugin.use` 权限授权，支持 owner、admin、viewer 等有权限用户下载。
- 用户请求以认证身份为准，避免伪造请求体绕过权限。
- 无权限、无下载地址、网络失败、包校验失败等情况改为记录日志并跳过，不再阻塞任务运行。
- 保持 MCP 连接器内嵌 Skill 的项目快照和 `local_only` 加载策略。