### PR TITLE
fix(chat): 修复会话超时后权限确认框反复弹出

### DIFF
--- a/frontend/packages/app-ui/components/input/ChatInput.tsx
+++ b/frontend/packages/app-ui/components/input/ChatInput.tsx
@@ -834,6 +834,8 @@ function findPendingApproval(
 		if (!message) continue;
 		if (activeSessionId && message.conversationId !== activeSessionId) continue;
 
+		if (message.status === "failed" || message.status === "completed") continue;
+
 		const approval = [...(message.approvals ?? [])]
 			.reverse()
 			.find(
@@ -861,6 +863,7 @@ function findPendingQuestion(
 	if (!lastId) return null;
 	const lastMessage = messagesMap[lastId];
 	if (!lastMessage?.questions?.length) return null;
+	if (lastMessage.status === "failed" || lastMessage.status === "completed") return null;
 
 	const question = lastMessage.questions[lastMessage.questions.length - 1];
 	if (

--- a/frontend/packages/store/chat/index.ts
+++ b/frontend/packages/store/chat/index.ts
@@ -44,6 +44,8 @@ export {
 	applySessionEventToMessage,
 	attachAssistantReplyTargets,
 	buildReplyToFromMessage,
+	expirePendingApprovals,
+	expirePendingQuestions,
 	getApprovalStatus,
 	mapBackendAttachment,
 	mapBackendMessage,

--- a/frontend/packages/store/chat/messageReducer.ts
+++ b/frontend/packages/store/chat/messageReducer.ts
@@ -81,6 +81,9 @@ export function mapBackendMessage(msg: BackendMessage): Message {
 		// 中文注释：历史消息的 chunks 只用于还原执行过程，不能重新把已落库回复标成生成中。
 		markStreaming: false,
 	});
+	// 中文注释：落库消息都是终态。超时取消后 chunks 里常只剩 approval.requested，
+	// 若不在此过期，切回会话会再次弹出权限确认框。
+	mapped = withExpiredPendingInteractions(mapped);
 	if (
 		mapped.role === "assistant" &&
 		mapped.todos?.length &&
@@ -303,6 +306,55 @@ export function completeTodos(todos: RuntimeTodoItem[] | undefined): RuntimeTodo
 	return todos.map((todo) =>
 		todo.status === "completed" ? todo : { ...todo, status: "completed" },
 	);
+}
+
+function isOpenApprovalStatus(status: ApprovalRequest["status"]): boolean {
+	return status === "pending" || status === "submitting" || status === "error";
+}
+
+function isOpenQuestionStatus(status: QuestionRequest["status"]): boolean {
+	return status === "pending" || status === "submitting" || status === "error";
+}
+
+/**
+ * run 已结束时把未决审批标为 expired，避免输入区继续弹出确认框。
+ */
+export function expirePendingApprovals(
+	approvals: ApprovalRequest[] | undefined,
+): ApprovalRequest[] | undefined {
+	if (!approvals?.length || !approvals.some((approval) => isOpenApprovalStatus(approval.status))) {
+		return approvals;
+	}
+	return approvals.map((approval) =>
+		isOpenApprovalStatus(approval.status)
+			? { ...approval, status: "expired", error: undefined }
+			: approval,
+	);
+}
+
+/**
+ * run 已结束时把未决问答标为 expired，避免输入区继续弹出提问框。
+ */
+export function expirePendingQuestions(
+	questions: QuestionRequest[] | undefined,
+): QuestionRequest[] | undefined {
+	if (!questions?.length || !questions.some((question) => isOpenQuestionStatus(question.status))) {
+		return questions;
+	}
+	return questions.map((question) =>
+		isOpenQuestionStatus(question.status)
+			? { ...question, status: "expired", error: undefined }
+			: question,
+	);
+}
+
+function withExpiredPendingInteractions(message: Message): Message {
+	const approvals = expirePendingApprovals(message.approvals);
+	const questions = expirePendingQuestions(message.questions);
+	if (approvals === message.approvals && questions === message.questions) {
+		return message;
+	}
+	return { ...message, approvals, questions };
 }
 
 /** 类型守卫：判断值是否为非 null 的普通对象。 */
@@ -1090,39 +1142,40 @@ export function applySessionEventToMessage(
 			const artifacts = payload.artifacts
 				?.map(mapArtifactPayload)
 				.filter((artifact): artifact is MessageArtifact => artifact !== undefined);
-			return enrichAssistantMessageMetrics({
-				...message,
-				status: "completed",
-				statusText: undefined,
-				content: options.appendContent && resultMessage ? resultMessage : message.content,
-				processSteps: pruneFinalContentProcessSteps(message.processSteps, resultMessage),
-				todos: completeTodos(message.todos),
-				artifacts: artifacts?.length
-					? mergeArtifacts(message.artifacts, artifacts)
-					: message.artifacts,
-				metadata: metadata ? { ...message.metadata, ...metadata } : message.metadata,
-				usage: usage ?? message.usage,
-			});
+			return enrichAssistantMessageMetrics(
+				withExpiredPendingInteractions({
+					...message,
+					status: "completed",
+					statusText: undefined,
+					content: options.appendContent && resultMessage ? resultMessage : message.content,
+					processSteps: pruneFinalContentProcessSteps(message.processSteps, resultMessage),
+					todos: completeTodos(message.todos),
+					artifacts: artifacts?.length
+						? mergeArtifacts(message.artifacts, artifacts)
+						: message.artifacts,
+					metadata: metadata ? { ...message.metadata, ...metadata } : message.metadata,
+					usage: usage ?? message.usage,
+				}),
+			);
 		}
 		case "run.failed": {
 			const failedMessage = getRunFailedMessage(payload);
-			if (!failedMessage) return message;
-			return {
+			return withExpiredPendingInteractions({
 				...message,
 				status: "failed",
 				statusText: undefined,
 				// 中文注释：失败事件也要回填到当前 assistant 消息里，避免界面只剩空占位。
-				content: failedMessage,
-			};
+				content: failedMessage || message.content,
+			});
 		}
 		case "run.cancelled": {
-			return {
+			return withExpiredPendingInteractions({
 				...message,
 				status: "failed",
 				statusText: undefined,
 				// 取消结果由后端持久化后回拉，避免前端默认文案与后端结果短暂闪烁。
 				content: message.content,
-			};
+			});
 		}
 		default:
 			return message;

--- a/frontend/packages/store/slices/chatSlice.test.ts
+++ b/frontend/packages/store/slices/chatSlice.test.ts
@@ -80,6 +80,61 @@ describe("applySessionEventToMessage waiting status", () => {
 	});
 });
 
+describe("pending approval expiry", () => {
+	const pendingApprovalMessage = (): Message => ({
+		...assistantMessage(),
+		status: "streaming",
+		approvals: [
+			{
+				requestId: "approval-1",
+				toolName: "shell",
+				description: "Run command",
+				status: "pending",
+			},
+		],
+	});
+
+	it("expires pending approval when the run is cancelled", () => {
+		const result = applySessionEventToMessage(
+			pendingApprovalMessage(),
+			{ type: "run.cancelled", payload: {} },
+			"run.cancelled",
+			{ appendContent: true },
+		);
+
+		expect(result.status).toBe("failed");
+		expect(result.approvals?.[0]?.status).toBe("expired");
+	});
+
+	it("does not restore a pending approval from cancelled history chunks", () => {
+		const result = mapBackendMessage({
+			id: "assistant-1",
+			session_id: "session-1",
+			role: "assistant",
+			content: "已取消",
+			timestamp: 1,
+			message_type: "text",
+			sequence: 2,
+			created_at: "2026-08-28T08:00:00.000Z",
+			chunks: [
+				{
+					type: "approval.requested",
+					session_id: "session-1",
+					payload: {
+						request_id: "approval-1",
+						tool_name: "shell",
+						description: "Run command",
+					},
+					sequence: 1,
+					timestamp: 1,
+				},
+			],
+		});
+
+		expect(result.approvals?.[0]?.status).toBe("expired");
+	});
+});
+
 describe("createAssistantSessionEventsWaitingMessage", () => {
 	it("keeps the waiting status when restoring an active SessionEvents replay", () => {
 		const message = createAssistantSessionEventsWaitingMessage(

--- a/frontend/packages/store/slices/chatSlice.ts
+++ b/frontend/packages/store/slices/chatSlice.ts
@@ -482,6 +482,17 @@ export class ChatActionImpl {
 			console.warn("submitApprovalDecision: missing assistantId, request may fail");
 		}
 
+		if (message?.status === "failed" || message?.status === "completed") {
+			this.#dispatchChat({
+				type: "updateApprovalStatus",
+				messageId,
+				requestId,
+				status: "expired",
+				error: undefined,
+			});
+			return;
+		}
+
 		this.#dispatchChat({
 			type: "updateApprovalStatus",
 			messageId,
@@ -533,6 +544,17 @@ export class ChatActionImpl {
 		const assistantId = question?.assistantId;
 		if (!assistantId) {
 			console.warn("submitQuestionAnswer: missing assistantId, request may fail");
+		}
+
+		if (message?.status === "failed" || message?.status === "completed") {
+			this.#dispatchChat({
+				type: "updateQuestionStatus",
+				messageId,
+				requestId,
+				status: "expired",
+				error: undefined,
+			});
+			return;
 		}
 
 		this.#dispatchChat({

--- a/frontend/packages/store/types/chat.ts
+++ b/frontend/packages/store/types/chat.ts
@@ -15,9 +15,16 @@ export type TodoStatus = "pending" | "in_progress" | "completed" | "cancelled";
 
 export type ApprovalAction = "approve" | "deny" | "always";
 
-export type ApprovalStatus = "pending" | "approved" | "denied" | "always" | "submitting" | "error";
+export type ApprovalStatus =
+	| "pending"
+	| "approved"
+	| "denied"
+	| "always"
+	| "submitting"
+	| "error"
+	| "expired";
 
-export type QuestionStatus = "pending" | "answered" | "submitting" | "error";
+export type QuestionStatus = "pending" | "answered" | "submitting" | "error" | "expired";
 
 export type ExecutionMode = "default" | "plan";
 


### PR DESCRIPTION
- 问答等待权限确认时若超时变成已取消，底部确认框仍会留下，切走再进还会再弹
- 原因是 chunks 里只有 approval.requested、没有 resolved，历史回放会把审批还原成 pending
- run 终态和 GetSessionMessages 回放后把未决审批/问答标为 expired，输入区不再替换成确认框
- 已结束的消息不再提交审批接口，避免失败后又回到待确认