### PR TITLE
fix(project): 修复项目列表全量加载与选择器悬停卡顿错位

### DIFF
--- a/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
+++ b/frontend/packages/app-ui/components/ai-teammates/ProjectsHubView.tsx
@@ -35,6 +35,7 @@ import {
 	Bot,
 	CalendarDays,
 	Check,
+	Loader2,
 	MessageSquare,
 	Plus,
 	Search,
@@ -45,6 +46,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useAuth } from "../auth";
+import { ListLoadMoreSentinel } from "../common/ListLoadMoreSentinel";
 import { MCPConnectorIcon } from "../common/MCPConnectorIcon";
 import { renderHighlightedText } from "../common/searchText";
 import { FieldWithError, RequiredMark, useFormFieldValidation } from "../form/formValidation";
@@ -52,6 +54,7 @@ import { bindSkillsToProject, useSkillPickerOptions } from "../input/useSkillPic
 import type { AppNavigation } from "../layout/LeftRail";
 import { ProjectIcon } from "../layout/project-icon";
 import { ProjectActionsDropdown } from "../project/ProjectActionsDropdown";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 import {
 	ProjectMemberChip,
 	ProjectMemberPickerDialog,
@@ -109,8 +112,6 @@ function formatProjectDate(timestamp: number) {
 
 export function ProjectsHubView({ navigation }: ProjectsHubViewProps) {
 	const {
-		projects,
-		fetchProjects,
 		createProject,
 		updateProject,
 		deleteProject,
@@ -120,14 +121,22 @@ export function ProjectsHubView({ navigation }: ProjectsHubViewProps) {
 		switchView,
 	} = useLayoutStore((s) => s);
 	const { isAuthenticated, requireAuth } = useAuth();
-	const visibleProjects = isAuthenticated ? projects : [];
-	useProjectsMenuCapabilities(visibleProjects.map((project) => project.id));
 	const [keyword, setKeyword] = useState("");
 	const [createOpen, setCreateOpen] = useState(false);
 	const [renameProject, setRenameProject] = useState<Project | null>(null);
 	const [renameValue, setRenameValue] = useState("");
 	const [deleteTarget, setDeleteTarget] = useState<Project | null>(null);
 	const [leaveTarget, setLeaveTarget] = useState<Project | null>(null);
+	const [listRoot, setListRoot] = useState<HTMLDivElement | null>(null);
+	const projectList = usePaginatedProjectList({
+		enabled: isAuthenticated,
+		keyword,
+	});
+	const displayedProjects = projectList.projects;
+	useProjectsMenuCapabilities(displayedProjects.map((project) => project.id));
+	const isSearching = keyword.trim().length > 0;
+	const showInitialLoading =
+		isAuthenticated && projectList.loading && displayedProjects.length === 0;
 
 	useEffect(() => {
 		if (isAuthenticated) return;
@@ -136,21 +145,6 @@ export function ProjectsHubView({ navigation }: ProjectsHubViewProps) {
 		setDeleteTarget(null);
 		setLeaveTarget(null);
 	}, [isAuthenticated]);
-
-	useEffect(() => {
-		if (!isAuthenticated) return;
-		fetchProjects();
-	}, [fetchProjects, isAuthenticated]);
-
-	const filteredProjects = useMemo(() => {
-		const query = keyword.trim().toLowerCase();
-		const sorted = [...visibleProjects].sort((a, b) => b.createdAt - a.createdAt);
-		if (!query) return sorted;
-
-		return sorted.filter((project) =>
-			[project.name, project.description].join(" ").toLowerCase().includes(query),
-		);
-	}, [keyword, visibleProjects]);
 
 	const openProject = (projectId: string) => {
 		requireAuth(() => {
@@ -259,34 +253,48 @@ export function ProjectsHubView({ navigation }: ProjectsHubViewProps) {
 				<div className="mb-4 flex shrink-0 items-center justify-between gap-4">
 					<h2 className="text-lg font-semibold text-[var(--leros-text-strong)]">我的项目</h2>
 					<span className="text-xs text-[var(--leros-text-subtle)]">
-						{filteredProjects.length} 个项目
+						{projectList.total} 个项目
 					</span>
 				</div>
 
-				<div className="min-h-0 flex-1 overflow-y-auto pr-1 no-scrollbar">
-					{filteredProjects.length === 0 ? (
+				<div ref={setListRoot} className="min-h-0 flex-1 overflow-y-auto pr-1 no-scrollbar">
+					{showInitialLoading ? (
+						<div className="flex min-h-[280px] items-center justify-center">
+							<Loader2 className="size-5 animate-spin text-[var(--leros-text-subtle)]" />
+						</div>
+					) : displayedProjects.length === 0 ? (
 						<div className="flex min-h-[280px] flex-col items-center justify-center rounded-xl border border-dashed border-[var(--leros-control-border)] bg-white/70 px-6 text-center">
 							<div className="mb-3 flex size-12 items-center justify-center rounded-xl bg-[var(--leros-primary-softer)] text-[var(--leros-primary)]">
 								<ProjectIcon className="size-6" />
 							</div>
-							<p className="text-sm font-semibold text-[var(--leros-text-strong)]">还没有项目</p>
+							<p className="text-sm font-semibold text-[var(--leros-text-strong)]">
+								{isSearching ? "没有匹配的项目" : "还没有项目"}
+							</p>
 							<p className="mt-1 text-sm text-[var(--leros-text-muted)]">
-								点击右上角新建一个空项目。
+								{isSearching ? "试试其他关键词。" : "点击右上角新建一个空项目。"}
 							</p>
 						</div>
 					) : (
-						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-							{filteredProjects.map((project) => (
-								<ProjectCard
-									key={project.id}
-									project={project}
-									onOpen={openProject}
-									onRename={openRename}
-									onDelete={setDeleteTarget}
-									onLeave={setLeaveTarget}
-								/>
-							))}
-						</div>
+						<>
+							<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+								{displayedProjects.map((project) => (
+									<ProjectCard
+										key={project.id}
+										project={project}
+										onOpen={openProject}
+										onRename={openRename}
+										onDelete={setDeleteTarget}
+										onLeave={setLeaveTarget}
+									/>
+								))}
+							</div>
+							<ListLoadMoreSentinel
+								hasMore={projectList.hasMore}
+								loading={projectList.loadingMore}
+								onLoadMore={projectList.loadMore}
+								root={listRoot}
+							/>
+						</>
 					)}
 				</div>
 			</main>

--- a/frontend/packages/app-ui/components/automation/AutomationFormDialog.test.tsx
+++ b/frontend/packages/app-ui/components/automation/AutomationFormDialog.test.tsx
@@ -52,7 +52,8 @@ const { skillPickerMock, storeMock } = vi.hoisted(() => ({
 	storeMock: {
 		createAutomation: vi.fn(async () => ({ ok: true, status: undefined })),
 		updateAutomation: vi.fn(async () => ({ ok: true, status: undefined })),
-		fetchProjects: vi.fn(async () => true),
+		fetchProjectListPage: vi.fn(),
+		upsertProjects: vi.fn(),
 	},
 }));
 
@@ -60,6 +61,7 @@ vi.mock("@leros/store", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@leros/store")>();
 	return {
 		...actual,
+		fetchProjectListPage: (...args: unknown[]) => storeMock.fetchProjectListPage(...args),
 		useAutomationStore: (selector: (state: unknown) => unknown) =>
 			selector({
 				createAutomation: storeMock.createAutomation,
@@ -68,7 +70,8 @@ vi.mock("@leros/store", async (importOriginal) => {
 		useLayoutStore: (selector: (state: unknown) => unknown) =>
 			selector({
 				projects: mockProjects,
-				fetchProjects: storeMock.fetchProjects,
+				projectsMutationEpoch: 0,
+				upsertProjects: storeMock.upsertProjects,
 			}),
 	};
 });
@@ -102,8 +105,26 @@ async function switchToMonthly(user: ReturnType<typeof userEvent.setup>) {
 
 beforeEach(() => {
 	mockProjects = [];
-	storeMock.fetchProjects.mockReset();
-	storeMock.fetchProjects.mockResolvedValue(true);
+	storeMock.fetchProjectListPage.mockReset();
+	storeMock.fetchProjectListPage.mockImplementation(async () => ({
+		items: mockProjects.map((project) => ({
+			id: project.id,
+			name: project.name,
+			description: "",
+			skills: [],
+			members: [],
+			taskCount: 0,
+			createdAt: 0,
+			updatedAt: 0,
+			messages: [],
+			tasks: [],
+			files: [],
+		})),
+		total: mockProjects.length,
+		offset: 0,
+		hasMore: false,
+	}));
+	storeMock.upsertProjects.mockReset();
 });
 
 afterEach(() => {
@@ -404,10 +425,10 @@ describe("AutomationFormDialog 关联项目选择", () => {
 	});
 
 	it("首次打开时已有项目仍在加载会展示加载提示", async () => {
-		let resolveFetch: ((value: boolean) => void) | undefined;
-		storeMock.fetchProjects.mockImplementationOnce(
+		let resolveFetch: ((value: unknown) => void) | undefined;
+		storeMock.fetchProjectListPage.mockImplementationOnce(
 			() =>
-				new Promise<boolean>((resolve) => {
+				new Promise((resolve) => {
 					resolveFetch = resolve;
 				}),
 		);
@@ -417,7 +438,7 @@ describe("AutomationFormDialog 关联项目选择", () => {
 		await user.click(screen.getByRole("button", { name: /^新项目$/ }));
 		expect(await screen.findByText("正在加载已有项目...")).toBeInTheDocument();
 
-		resolveFetch?.(true);
+		resolveFetch?.({ items: [], total: 0, offset: 0, hasMore: false });
 	});
 
 	it("编辑切回默认新项目时提交 project_public_id 空串", async () => {

--- a/frontend/packages/app-ui/components/automation/AutomationFormDialog.tsx
+++ b/frontend/packages/app-ui/components/automation/AutomationFormDialog.tsx
@@ -44,9 +44,11 @@ import { Switch } from "@leros/ui/components/ui/switch";
 import { Check, ChevronsUpDown, Clock, FolderOpen } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ListLoadMoreSentinel } from "../common/ListLoadMoreSentinel";
 import { StructuredComposer, type StructuredComposerHandle } from "../input/StructuredComposer";
 import { useComposerSkillOptions } from "../input/useComposerSkillOptions";
 import { ProjectIcon } from "../layout/project-icon";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 import {
 	type AutomationScheduleFormState,
 	buildFormSummary,
@@ -89,8 +91,7 @@ export function AutomationFormDialog({
 	onClose,
 }: AutomationFormDialogProps) {
 	const { createAutomation, updateAutomation } = useAutomationStore((s) => s);
-	const projects = useLayoutStore((s) => s.projects);
-	const fetchProjects = useLayoutStore((s) => s.fetchProjects);
+	const cachedProjects = useLayoutStore((s) => s.projects);
 	const [form, setForm] = useState<AutomationScheduleFormState>(DEFAULT_SCHEDULE_FORM);
 	const [name, setName] = useState("");
 	const [instruction, setInstruction] = useState("");
@@ -107,61 +108,46 @@ export function AutomationFormDialog({
 	const [selectedProjectId, setSelectedProjectId] = useState("");
 	const [projectSearch, setProjectSearch] = useState("");
 	const [projectPickerOpen, setProjectPickerOpen] = useState(false);
-	const [projectListLoading, setProjectListLoading] = useState(false);
-	const [projectListReady, setProjectListReady] = useState(false);
+	const [listRoot, setListRoot] = useState<HTMLDivElement | null>(null);
+	const projectList = usePaginatedProjectList({
+		enabled: open,
+		keyword: projectSearch,
+	});
+	const existingProjects = projectList.projects;
+	const projectListLoading = projectList.loading && existingProjects.length === 0;
 
 	const isEdit = Boolean(editTarget);
 	const { skillOptions, skillsLoading } = useComposerSkillOptions(selectedProjectId || null, open);
 	const nextRunPreview = useMemo(() => computeNextRunPreview(form, timezone), [form, timezone]);
 
-	// ListProjects 已按当前用户的项目绑定过滤；关联项目的最终可用性仍由保存接口权威校验。
-	// 不在弹窗中二次权限过滤，避免首次打开时因批量权限请求未完成而隐藏完整项目列表。
-	useEffect(() => {
-		if (!open) {
-			setProjectListLoading(false);
-			setProjectListReady(false);
-			return;
-		}
-
-		let active = true;
-		setProjectListLoading(true);
-		setProjectListReady(false);
-		void fetchProjects()
-			.then((succeeded) => {
-				if (!active) return;
-				setProjectListReady(succeeded);
-				setProjectListLoading(false);
-			})
-			.catch(() => {
-				if (!active) return;
-				setProjectListReady(false);
-				setProjectListLoading(false);
-			});
-
-		return () => {
-			active = false;
-		};
-	}, [fetchProjects, open]);
-
-	// 已有项目按搜索词过滤。列表接口已确保当前用户可见，服务端在保存时继续校验权限和 AI 队友绑定。
-	const existingProjects = useMemo(() => {
-		const q = projectSearch.trim().toLowerCase();
-		return projects.filter((p) => !q || p.name.toLowerCase().includes(q));
-	}, [projectSearch, projects]);
-
 	// 当前选中项目的展示名（用于触发按钮）；未选中显示"新项目"
 	const selectedProjectLabel = useMemo(() => {
 		if (!selectedProjectId) return "";
-		return projects.find((p) => p.id === selectedProjectId)?.name ?? editTarget?.projectName ?? "";
-	}, [editTarget?.projectName, projects, selectedProjectId]);
+		return (
+			cachedProjects.find((p) => p.id === selectedProjectId)?.name ??
+			existingProjects.find((p) => p.id === selectedProjectId)?.name ??
+			editTarget?.projectName ??
+			""
+		);
+	}, [cachedProjects, editTarget?.projectName, existingProjects, selectedProjectId]);
 
-	// 编辑时选中了项目但该项目已不在用户可访问的项目列表中 => 提示改选
 	const selectedProjectIsUnavailable = useMemo(() => {
 		if (!isEdit || !editTarget?.projectPublicId) return false;
-		if (!projectListReady || projectListLoading) return false;
+		if (projectList.loading || projectSearch.trim() || projectList.hasMore) return false;
 		const pid = editTarget.projectPublicId;
-		return !projects.some((project) => project.id === pid);
-	}, [editTarget?.projectPublicId, isEdit, projectListLoading, projectListReady, projects]);
+		return (
+			!existingProjects.some((project) => project.id === pid) &&
+			!cachedProjects.some((project) => project.id === pid)
+		);
+	}, [
+		cachedProjects,
+		editTarget?.projectPublicId,
+		existingProjects,
+		isEdit,
+		projectList.hasMore,
+		projectList.loading,
+		projectSearch,
+	]);
 
 	// 编辑且存在活动执行时禁止更换项目
 	const projectDisabled = Boolean(editTarget?.hasActiveExecution);
@@ -476,7 +462,7 @@ export function AutomationFormDialog({
 												onValueChange={setProjectSearch}
 												placeholder="搜索项目"
 											/>
-											<CommandList className="max-h-60">
+											<CommandList ref={setListRoot} className="max-h-60">
 												<CommandGroup heading="新项目" className="p-0">
 													<CommandItem
 														value="__default__"
@@ -520,6 +506,13 @@ export function AutomationFormDialog({
 															)}
 														</CommandItem>
 													))}
+													<ListLoadMoreSentinel
+														hasMore={projectList.hasMore}
+														loading={projectList.loadingMore}
+														onLoadMore={projectList.loadMore}
+														root={listRoot}
+														className="py-2"
+													/>
 												</CommandGroup>
 											</CommandList>
 										</Command>

--- a/frontend/packages/app-ui/components/common/ListLoadMoreSentinel.tsx
+++ b/frontend/packages/app-ui/components/common/ListLoadMoreSentinel.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { cn } from "@leros/ui/lib/utils";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+type ListLoadMoreSentinelProps = {
+	hasMore: boolean;
+	loading: boolean;
+	onLoadMore: () => void;
+	root?: Element | null;
+	className?: string;
+};
+
+export function ListLoadMoreSentinel({
+	hasMore,
+	loading,
+	onLoadMore,
+	root,
+	className,
+}: ListLoadMoreSentinelProps) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!hasMore || loading) return;
+		const node = ref.current;
+		if (!node) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					onLoadMore();
+				}
+			},
+			{ root: root ?? null, rootMargin: "160px", threshold: 0 },
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [hasMore, loading, onLoadMore, root]);
+
+	if (!hasMore && !loading) return null;
+
+	return (
+		<div
+			ref={ref}
+			className={cn("flex items-center justify-center py-3", className)}
+			role="status"
+			aria-label={loading ? "加载更多" : "还有更多"}
+		>
+			{loading ? (
+				<Loader2 className="size-4 animate-spin text-[var(--leros-text-subtle)]" />
+			) : (
+				<span className="sr-only">滚动加载更多</span>
+			)}
+		</div>
+	);
+}

--- a/frontend/packages/app-ui/components/input/BidComparisonConfigDialog.tsx
+++ b/frontend/packages/app-ui/components/input/BidComparisonConfigDialog.tsx
@@ -16,6 +16,7 @@ import { cn } from "@leros/ui/lib/utils";
 import { Eye, FileText, FolderOpen, LoaderCircle, Search, Upload, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BidComparisonIcon } from "../../assets";
+import { ListLoadMoreSentinel } from "../common/ListLoadMoreSentinel";
 import { filePreviewActions } from "../layout/file-preview-store";
 import { ProjectTaskPickerField } from "../layout/ProjectTaskPicker";
 import { ProjectFileTypeIcon } from "../layout/project-file-type-icon";
@@ -24,6 +25,7 @@ import {
 	type ProjectFileNode,
 	parseProjectFileList,
 } from "../layout/project-files";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 
 export type BidComparisonProjectFile = {
 	name: string;
@@ -201,7 +203,6 @@ export function BidComparisonConfigDialog({
 
 				<div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-7 py-5">
 					<ProjectTaskPickerField
-						projects={projects}
 						projectId={targetProjectId}
 						taskId={targetTaskId}
 						allowNewProject
@@ -428,7 +429,6 @@ function FilePickerSection({
 export function ProjectFilePicker({
 	open,
 	mode,
-	projects,
 	initialSelected = [],
 	reservedCount = 0,
 	maxCountOverride,
@@ -438,7 +438,7 @@ export function ProjectFilePicker({
 }: {
 	open: boolean;
 	mode: "main" | "compare";
-	projects: BidComparisonProjectOption[];
+	projects?: BidComparisonProjectOption[];
 	initialSelected?: BidComparisonProjectFile[];
 	/** 中文注释：已占用的本地上传名额，对比文件总上限仍为 10。 */
 	reservedCount?: number;
@@ -449,8 +449,10 @@ export function ProjectFilePicker({
 }) {
 	const maxCount = maxCountOverride ?? (mode === "main" ? 1 : Math.max(0, 10 - reservedCount));
 	const title = titleOverride ?? (mode === "main" ? "选择投标文件" : "选择对比文件");
-	// 中文注释：项目顺序与侧边栏一致，不做名称重排。
-	const [selectedProjectId, setSelectedProjectId] = useState(projects[0]?.id ?? "");
+	const projectList = usePaginatedProjectList({ enabled: open });
+	const projects = projectList.projects;
+	const [selectRoot, setSelectRoot] = useState<HTMLDivElement | null>(null);
+	const [selectedProjectId, setSelectedProjectId] = useState("");
 	const [projectTrees, setProjectTrees] = useState<Record<string, ProjectFileNode[]>>({});
 	const [loading, setLoading] = useState(false);
 	const [loadError, setLoadError] = useState("");
@@ -460,6 +462,13 @@ export function ProjectFilePicker({
 	initialSelectedRef.current = initialSelected;
 
 	const selectedProject = projects.find((project) => project.id === selectedProjectId);
+
+	useEffect(() => {
+		if (!open) return;
+		if (!selectedProjectId && projects[0]?.id) {
+			setSelectedProjectId(projects[0].id);
+		}
+	}, [open, projects, selectedProjectId]);
 	const selectedFiles = useMemo(() => Object.values(selectedMap), [selectedMap]);
 	const totalSelectedCount = selectedFiles.length + (mode === "compare" ? reservedCount : 0);
 	const totalMaxCount = mode === "main" ? 1 : maxCount + reservedCount;
@@ -597,9 +606,10 @@ export function ProjectFilePicker({
 							</SelectTrigger>
 							{projects.length > 0 ? (
 								<SelectContent
+									ref={setSelectRoot}
 									align="start"
 									side="bottom"
-									className="z-[70] max-h-64 min-w-[var(--anchor-width)] rounded-xl border border-slate-200 bg-white p-1 shadow-lg"
+									className="z-[70] max-h-64 min-w-[var(--anchor-width)] overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg"
 								>
 									{projects.map((project) => (
 										<SelectItem
@@ -610,6 +620,15 @@ export function ProjectFilePicker({
 											{project.name}
 										</SelectItem>
 									))}
+									<ListLoadMoreSentinel
+										hasMore={projectList.hasMore}
+										loading={
+											projectList.loadingMore || (projectList.loading && projects.length === 0)
+										}
+										onLoadMore={projectList.loadMore}
+										root={selectRoot}
+										className="py-2"
+									/>
 								</SelectContent>
 							) : null}
 						</Select>

--- a/frontend/packages/app-ui/components/layout/GlobalTaskSearchDialog.tsx
+++ b/frontend/packages/app-ui/components/layout/GlobalTaskSearchDialog.tsx
@@ -9,7 +9,9 @@ import { cn } from "@leros/ui/lib/utils";
 import { Loader2, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ListLoadMoreSentinel } from "../common/ListLoadMoreSentinel";
 import { renderHighlightedText } from "../common/searchText";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 import type { AppNavigation } from "./LeftRail";
 import { ProjectIcon } from "./project-icon";
 
@@ -53,11 +55,11 @@ export function GlobalTaskSearchDialog({
 	onOpenChange: (open: boolean) => void;
 	navigation?: AppNavigation;
 }) {
-	const { projects, fetchProjects, openTaskDetail } = useLayoutStore((state) => ({
-		projects: state.projects,
-		fetchProjects: state.fetchProjects,
-		openTaskDetail: state.openTaskDetail,
-	}));
+	const cachedProjects = useLayoutStore((state) => state.projects);
+	const openTaskDetail = useLayoutStore((state) => state.openTaskDetail);
+	const projectList = usePaginatedProjectList({ enabled: open });
+	const projects = projectList.projects;
+	const [selectRoot, setSelectRoot] = useState<HTMLDivElement | null>(null);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const requestIdRef = useRef(0);
 	const loadingTimerRef = useRef<number | null>(null);
@@ -70,15 +72,12 @@ export function GlobalTaskSearchDialog({
 
 	const selectedProjectLabel = useMemo(() => {
 		if (selectedProjectId === ALL_PROJECTS_VALUE) return "全部项目";
-		return projects.find((project) => project.id === selectedProjectId)?.name ?? "全部项目";
-	}, [projects, selectedProjectId]);
-
-	useEffect(() => {
-		if (!open) return;
-		if (projects.length === 0) {
-			void fetchProjects();
-		}
-	}, [fetchProjects, open, projects.length]);
+		return (
+			projects.find((project) => project.id === selectedProjectId)?.name ??
+			cachedProjects.find((project) => project.id === selectedProjectId)?.name ??
+			"全部项目"
+		);
+	}, [cachedProjects, projects, selectedProjectId]);
 
 	useEffect(() => {
 		if (!open) return;
@@ -155,7 +154,9 @@ export function GlobalTaskSearchDialog({
 	const resolveTaskSessionId = (task: BackendTask): string | null => {
 		const sessionIdFromTask = task.session?.session_id?.trim();
 		if (sessionIdFromTask) return sessionIdFromTask;
-		const project = projects.find((item) => item.id === task.project_id);
+		const project =
+			projects.find((item) => item.id === task.project_id) ??
+			cachedProjects.find((item) => item.id === task.project_id);
 		return project?.tasks.find((item) => item.id === task.public_id)?.sessionId ?? null;
 	};
 
@@ -205,6 +206,7 @@ export function GlobalTaskSearchDialog({
 									</span>
 								</SelectTrigger>
 								<SelectContent
+									ref={setSelectRoot}
 									align="start"
 									side="bottom"
 									sideOffset={8}
@@ -233,6 +235,14 @@ export function GlobalTaskSearchDialog({
 											</span>
 										</SelectItem>
 									))}
+									<ListLoadMoreSentinel
+										hasMore={projectList.hasMore}
+										loading={
+											projectList.loadingMore || (projectList.loading && projects.length === 0)
+										}
+										onLoadMore={projectList.loadMore}
+										root={selectRoot}
+									/>
 								</SelectContent>
 							</Select>
 						</div>

--- a/frontend/packages/app-ui/components/layout/LeftRail.test.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.test.tsx
@@ -23,6 +23,7 @@ let mockIsAuthenticated = true;
 let mockProjects: Array<{
 	id: string;
 	name: string;
+	updatedAt: number;
 	tasks: Array<{ id: string; title: string }>;
 }> = [];
 

--- a/frontend/packages/app-ui/components/layout/LeftRail.test.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.test.tsx
@@ -6,7 +6,6 @@ import { LeftRail } from "./LeftRail";
 
 const mockAuthenticatedFetch = vi.fn();
 const mockFetchFilePreviewByPublicId = vi.fn();
-const mockFetchProjects = vi.fn();
 const mockFetchTasks = vi.fn();
 const mockDeleteProject = vi.fn();
 const mockSetLeftRailCollapsed = vi.fn();
@@ -15,6 +14,7 @@ const mockSwitchView = vi.fn();
 const mockSwitchProject = vi.fn();
 const mockOpenTaskDetail = vi.fn();
 const mockUpdateProject = vi.fn();
+const mockUpsertProjects = vi.fn();
 const mockClearComposerInput = vi.fn();
 const mockSetAuthUser = vi.fn();
 const mockLogout = vi.fn();
@@ -43,6 +43,15 @@ vi.mock("@leros/store", () => ({
 	normalizeFilePublicId: (value?: string) => value?.match(/file_[A-Za-z0-9_-]+/)?.[0],
 	LEFT_RAIL_MAX_WIDTH: 360,
 	LEFT_RAIL_MIN_WIDTH: 220,
+	PROJECT_LIST_PAGE_SIZE: 20,
+	fetchProjectListPage: async () => ({
+		items: mockProjects,
+		total: mockProjects.length,
+		offset: 0,
+		hasMore: false,
+	}),
+	mergeProjectsFromListResult: (items: unknown[]) => items,
+	appendProjectsFromListResult: (incoming: unknown[], local: unknown[]) => [...local, ...incoming],
 	projectFileApi: {},
 	useProjectMenuCapabilities: () => ({ loading: false, hasAny: false }),
 	useProjectsMenuCapabilities: vi.fn(),
@@ -55,9 +64,10 @@ vi.mock("@leros/store", () => ({
 			activeProjectId: null,
 			activeTaskDetailProjectId: "project-1",
 			activeTaskDetailTaskId: "task-1",
+			projectsMutationEpoch: 0,
 			leftRailCollapsed: false,
 			leftRailWidth: 240,
-			fetchProjects: mockFetchProjects,
+			upsertProjects: mockUpsertProjects,
 			fetchTasks: mockFetchTasks,
 			deleteProject: mockDeleteProject,
 			setLeftRailCollapsed: mockSetLeftRailCollapsed,
@@ -135,7 +145,6 @@ describe("LeftRail avatar download", () => {
 			ok: true,
 			blob: async () => new Blob(["avatar"], { type: "image/png" }),
 		});
-		mockFetchProjects.mockReset();
 		mockFetchTasks.mockReset();
 		mockDeleteProject.mockReset();
 		mockSetLeftRailCollapsed.mockReset();
@@ -168,8 +177,7 @@ describe("LeftRail avatar download", () => {
 describe("LeftRail project expansion", () => {
 	beforeEach(() => {
 		mockIsAuthenticated = true;
-		mockProjects = [{ id: "project-1", name: "测试项目", tasks: [] }];
-		mockFetchProjects.mockReset();
+		mockProjects = [{ id: "project-1", name: "测试项目", tasks: [], updatedAt: 1 }];
 		mockFetchTasks.mockReset();
 		window.localStorage.clear();
 	});
@@ -179,7 +187,7 @@ describe("LeftRail project expansion", () => {
 
 		const { rerender } = render(<LeftRail />);
 
-		fireEvent.click(screen.getByText("测试项目"));
+		fireEvent.click(await screen.findByText("测试项目"));
 		await waitFor(() => {
 			expect(screen.getByText("暂无任务")).toBeInTheDocument();
 		});
@@ -197,7 +205,7 @@ describe("LeftRail project expansion", () => {
 
 		const { rerender } = render(<LeftRail />);
 
-		fireEvent.click(screen.getByText("测试项目"));
+		fireEvent.click(await screen.findByText("测试项目"));
 		await waitFor(() => {
 			expect(screen.getByText("暂无任务")).toBeInTheDocument();
 		});
@@ -217,7 +225,7 @@ describe("LeftRail project expansion", () => {
 		);
 
 		render(<LeftRail />);
-		fireEvent.click(screen.getByText("测试项目"));
+		fireEvent.click(await screen.findByText("测试项目"));
 
 		expect(screen.getByText("任务加载中...")).toBeInTheDocument();
 		expect(screen.queryByText("暂无任务")).not.toBeInTheDocument();

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -77,12 +77,14 @@ import {
 	cacheProtectedImageDataURL,
 	ProtectedImage,
 } from "../avatar/ProtectedImage";
+import { ListLoadMoreSentinel } from "../common/ListLoadMoreSentinel";
 import { FeedbackDialog } from "../feedback/FeedbackDialog";
 import { OrganizationSwitchPanel } from "../org-admin/OrganizationSwitchPanel";
 import { CanGate } from "../permission/CanGate";
 import { useBrandIdentity } from "../private-deployment/useBrandIdentity";
 import { ProjectActionsDropdown } from "../project/ProjectActionsDropdown";
 import { preventRailMenuClickThrough, runRailMenuAction } from "../project/ProjectActionsMenu";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 import { GlobalTaskSearchDialog } from "./GlobalTaskSearchDialog";
 import { getRecentProjectsForLeftRail } from "./left-rail-list-utils";
 import { ProjectIcon } from "./project-icon";
@@ -176,14 +178,12 @@ export function LeftRail({
 	const { logo: customBrandLogo, name: brandName } = useBrandIdentity();
 	const {
 		navGroups,
-		projects,
 		currentView,
 		activeProjectId,
 		activeTaskDetailProjectId,
 		activeTaskDetailTaskId,
 		leftRailCollapsed,
 		leftRailWidth,
-		fetchProjects,
 		fetchTasks,
 		deleteProject,
 		deleteTask,
@@ -203,7 +203,8 @@ export function LeftRail({
 	const { isHydrated, isAuthenticated, openAuthDialog, requireAuth, logout, user } = useAuth();
 	// 中文注释：OSS 版无多组织切换，隐藏左下角用户菜单中的「切换组织」入口。
 	const canSwitchOrganization = edition !== "oss";
-	const visibleProjects = isAuthenticated ? projects : [];
+	const projectList = usePaginatedProjectList({ enabled: isAuthenticated });
+	const visibleProjects = isAuthenticated ? projectList.projects : [];
 	useProjectsMenuCapabilities(visibleProjects.map((project) => project.id));
 	const [renameProject, setRenameProject] = useState<Project | null>(null);
 	const [renameTask, setRenameTask] = useState<ProjectTask | null>(null);
@@ -368,12 +369,6 @@ export function LeftRail({
 	};
 	/* ── end Desktop update notifier ── */
 
-	useEffect(() => {
-		if (!isAuthenticated) return;
-		void fetchProjects();
-	}, [fetchProjects, isAuthenticated]);
-
-	// 中文注释：项目展开态属于当前登录会话的浏览上下文，登出后应重置，避免重新登录后仍显示空的展开列表。
 	useEffect(() => {
 		if (isAuthenticated) return;
 		resetProjectExpansionState();
@@ -816,6 +811,9 @@ export function LeftRail({
 									onRenameTask={handleOpenTaskRename}
 									onDeleteTask={(task, projectId) => setDeleteTaskTarget({ task, projectId })}
 									collapsed={false}
+									hasMore={projectList.hasMore}
+									loadingMore={projectList.loadingMore}
+									onLoadMore={projectList.loadMore}
 								/>
 							</section>
 						)}
@@ -1730,6 +1728,9 @@ function ProjectList({
 	onRenameTask,
 	onDeleteTask,
 	collapsed,
+	hasMore,
+	loadingMore,
+	onLoadMore,
 }: {
 	projects: Project[];
 	activeProjectId: string | null;
@@ -1750,11 +1751,16 @@ function ProjectList({
 	onRenameTask: (task: ProjectTask) => void;
 	onDeleteTask: (task: ProjectTask, projectId: string) => void;
 	collapsed: boolean;
+	hasMore?: boolean;
+	loadingMore?: boolean;
+	onLoadMore?: () => void;
 }) {
 	const recentProjects = getRecentProjectsForLeftRail(projects);
+	const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
 
 	return (
 		<div
+			ref={setScrollRoot}
 			className={cn("no-scrollbar min-h-0 flex-1 space-y-1 overflow-y-auto", !collapsed && "pr-1")}
 		>
 			{recentProjects.map((project) => {
@@ -1875,6 +1881,14 @@ function ProjectList({
 					</div>
 				);
 			})}
+			{onLoadMore ? (
+				<ListLoadMoreSentinel
+					hasMore={Boolean(hasMore)}
+					loading={Boolean(loadingMore)}
+					onLoadMore={onLoadMore}
+					root={scrollRoot}
+				/>
+			) : null}
 		</div>
 	);
 }

--- a/frontend/packages/app-ui/components/layout/NewTaskPage.tsx
+++ b/frontend/packages/app-ui/components/layout/NewTaskPage.tsx
@@ -57,6 +57,7 @@ import { useComposerSkillOptions } from "../input/useComposerSkillOptions";
 import { useBrandIdentity } from "../private-deployment/useBrandIdentity";
 import { openPendingAttachmentPreview } from "./file-preview-store";
 import type { AppNavigation } from "./LeftRail";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 import { formatProjectTaskPickerLabel, ProjectTaskPickerContent } from "./ProjectTaskPicker";
 import { ProjectIcon } from "./project-icon";
 
@@ -209,6 +210,10 @@ export function NewTaskPage({ navigation }: { navigation?: AppNavigation }) {
 	const [isSending, setIsSending] = useState(false);
 	const [projectMenuOpen, setProjectMenuOpen] = useState(false);
 	const [projectSearch, setProjectSearch] = useState("");
+	const projectList = usePaginatedProjectList({
+		enabled: isAuthenticated,
+		keyword: projectSearch,
+	});
 	const [isDesktopApp, setIsDesktopApp] = useState(false);
 	const applyingWorkbenchPrefillIdRef = useRef<string | null>(null);
 	const wasAuthenticatedRef = useRef(isAuthenticated);
@@ -925,7 +930,11 @@ export function NewTaskPage({ navigation }: { navigation?: AppNavigation }) {
 							className="!flex-none w-auto overflow-visible rounded-none border-0 bg-transparent p-0 shadow-none ring-0"
 						>
 							<ProjectTaskPickerContent
-								projects={isAuthenticated ? projects : []}
+								projects={projectList.projects}
+								listLoading={projectList.loading}
+								hasMore={projectList.hasMore}
+								loadingMore={projectList.loadingMore}
+								onLoadMore={projectList.loadMore}
 								selectedProjectId={activeWorkbenchProjectId}
 								selectedTaskId={activeWorkbenchTaskId}
 								searchQuery={projectSearch}

--- a/frontend/packages/app-ui/components/layout/ProjectTaskPicker.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectTaskPicker.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import type { Project, ProjectTask } from "@leros/store";
+import { useLayoutStore } from "@leros/store";
 import { Command, CommandInput } from "@leros/ui/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@leros/ui/components/ui/popover";
 import { cn } from "@leros/ui/lib/utils";
 import { Check, ChevronDown, ChevronRight, ListTodo, LoaderCircle, Plus } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ListLoadMoreSentinel } from "../common/ListLoadMoreSentinel";
 import { renderHighlightedText } from "../common/searchText";
+import { usePaginatedProjectList } from "../project/usePaginatedProjectList";
 import { ProjectIcon } from "./project-icon";
 
 export type ProjectTaskPickerProject = Pick<Project, "id" | "name" | "tasks">;
@@ -24,6 +27,7 @@ const PROJECT_PICKER_SUBMENU_BLOCK_PADDING_PX = 12;
 const PROJECT_PICKER_SUBMENU_PADDING_TOP_PX = 6;
 const PROJECT_PICKER_SUBMENU_PANEL_CLASS =
 	"no-scrollbar absolute left-[calc(100%+4px)] z-50 w-[260px] overflow-y-auto rounded-2xl border border-slate-200/80 bg-white/95 p-1.5 shadow-[0_18px_45px_rgba(15,23,42,0.16)] backdrop-blur";
+const PROJECT_PICKER_HOVER_SUBMENU_MS = 500;
 
 function getFilteredProjects(projects: ProjectTaskPickerProject[], query: string) {
 	const keyword = query.trim().toLowerCase();
@@ -33,24 +37,33 @@ function getFilteredProjects(projects: ProjectTaskPickerProject[], query: string
 
 function estimateSubmenuHeightForFlip(
 	submenu: string,
-	project: ProjectTaskPickerProject | undefined,
-	isLoadingTasks: boolean,
+	taskCount: number,
+	showTasks: boolean,
+	isLoading: boolean,
 ): number {
-	// 中文注释：右侧始终含「新建任务」一行；已有任务时再加分割线与任务行。
 	let contentHeight = PROJECT_PICKER_ROW_HEIGHT_PX;
 	if (submenu.startsWith("project:")) {
-		const taskCount = project?.tasks.length ?? 0;
-		if (taskCount > 0) {
+		const listCount = showTasks && taskCount > 0 ? taskCount : isLoading ? 1 : 0;
+		if (listCount > 0) {
 			contentHeight +=
-				PROJECT_PICKER_SUBMENU_BLOCK_PADDING_PX + taskCount * PROJECT_PICKER_ROW_HEIGHT_PX;
-		} else if (isLoadingTasks) {
-			contentHeight += PROJECT_PICKER_ROW_HEIGHT_PX;
+				PROJECT_PICKER_SUBMENU_BLOCK_PADDING_PX + listCount * PROJECT_PICKER_ROW_HEIGHT_PX;
 		}
 	}
 	return Math.min(
 		PROJECT_PICKER_SUBMENU_MAX_HEIGHT_PX,
 		contentHeight + PROJECT_PICKER_SUBMENU_BLOCK_PADDING_PX,
 	);
+}
+
+function isRowVisibleInClip(row: HTMLElement, clip: HTMLElement | null): boolean {
+	const rowRect = row.getBoundingClientRect();
+	if (rowRect.height <= 0 || rowRect.width <= 0) return false;
+	if (!clip) {
+		return rowRect.bottom > 0 && rowRect.top < window.innerHeight;
+	}
+	const clipRect = clip.getBoundingClientRect();
+	const overlap = Math.min(rowRect.bottom, clipRect.bottom) - Math.max(rowRect.top, clipRect.top);
+	return overlap >= rowRect.height * 0.6;
 }
 
 function resolveSubmenuTop(rootRect: DOMRect, rowTop: number, submenuHeight: number): number {
@@ -79,16 +92,10 @@ function projectPickerRowClass(selected: boolean) {
 }
 
 function projectPickerPlaceholderRowClass() {
-	return cn(projectPickerRowClass(false), "pointer-events-none text-xs text-slate-400");
+	return cn(projectPickerRowClass(false), "pointer-events-none text-slate-400");
 }
 
-function NewTaskPickerRow({
-	selected,
-	onClick,
-}: {
-	selected: boolean;
-	onClick: () => void;
-}) {
+function NewTaskPickerRow({ selected, onClick }: { selected: boolean; onClick: () => void }) {
 	return (
 		<button type="button" onClick={onClick} className={projectPickerRowClass(selected)}>
 			<Plus className="size-4 shrink-0" />
@@ -111,7 +118,13 @@ export function formatProjectTaskPickerLabel(
 }
 
 export type ProjectTaskPickerContentProps = {
-	projects: ProjectTaskPickerProject[];
+	projects?: ProjectTaskPickerProject[];
+	listLoading?: boolean;
+	hasMore?: boolean;
+	loadingMore?: boolean;
+	onLoadMore?: () => void;
+	/** When false, skip fetching even if `projects` is omitted. */
+	listEnabled?: boolean;
 	selectedProjectId?: string | null;
 	selectedTaskId?: string | null;
 	searchQuery: string;
@@ -129,7 +142,12 @@ export type ProjectTaskPickerContentProps = {
 
 /** 中文注释：工作台与标书对比共用的项目/任务选择面板，含右侧二级任务侧边栏。 */
 export function ProjectTaskPickerContent({
-	projects,
+	projects: projectsProp,
+	listLoading: listLoadingProp,
+	hasMore: hasMoreProp,
+	loadingMore: loadingMoreProp,
+	onLoadMore: onLoadMoreProp,
+	listEnabled = true,
 	selectedProjectId,
 	selectedTaskId,
 	searchQuery,
@@ -143,17 +161,41 @@ export function ProjectTaskPickerContent({
 	scrollSelectedIntoView = false,
 }: ProjectTaskPickerContentProps) {
 	const pickerRootRef = useRef<HTMLDivElement>(null);
+	const [listRoot, setListRoot] = useState<HTMLDivElement | null>(null);
 	const submenuRowRef = useRef<HTMLElement | null>(null);
 	const [hoveredSubmenu, setHoveredSubmenu] = useState<"new-project" | `project:${string}` | null>(
 		null,
 	);
 	const [submenuTop, setSubmenuTop] = useState(0);
 	const [loadingTaskProjectIds, setLoadingTaskProjectIds] = useState<Set<string>>(() => new Set());
+	const [revealedTaskProjectId, setRevealedTaskProjectId] = useState<string | null>(null);
+	const submenuTimerRef = useRef<number | null>(null);
+	const hoverSessionRef = useRef(0);
+	const lastPointerRef = useRef({ x: 0, y: 0 });
+	const scrollSettleTimerRef = useRef<number | null>(null);
 
-	const filteredProjects = useMemo(
-		() => getFilteredProjects(projects, searchQuery),
-		[projects, searchQuery],
-	);
+	const clearSubmenuTimer = useCallback(() => {
+		if (submenuTimerRef.current == null) return;
+		window.clearTimeout(submenuTimerRef.current);
+		submenuTimerRef.current = null;
+	}, []);
+
+	const beginHoverSession = useCallback(() => {
+		hoverSessionRef.current += 1;
+		clearSubmenuTimer();
+		setRevealedTaskProjectId(null);
+	}, [clearSubmenuTimer]);
+	const shouldFetchList = projectsProp == null && listEnabled;
+	const projectList = usePaginatedProjectList({
+		enabled: shouldFetchList,
+		keyword: searchQuery,
+	});
+	const projects = projectsProp ?? projectList.projects;
+	const visibleProjects = projectsProp ? getFilteredProjects(projects, searchQuery) : projects;
+	const listLoading = shouldFetchList ? projectList.loading : Boolean(listLoadingProp);
+	const listHasMore = shouldFetchList ? projectList.hasMore : Boolean(hasMoreProp);
+	const listLoadingMore = shouldFetchList ? projectList.loadingMore : Boolean(loadingMoreProp);
+	const onLoadMore = shouldFetchList ? projectList.loadMore : onLoadMoreProp;
 	const hoveredProject =
 		hoveredSubmenu?.startsWith("project:") === true
 			? projects.find((project) => project.id === hoveredSubmenu.slice("project:".length))
@@ -161,12 +203,15 @@ export function ProjectTaskPickerContent({
 	const hoveredProjectTaskLoading = hoveredProject
 		? loadingTaskProjectIds.has(hoveredProject.id)
 		: false;
+	const showHoveredProjectTasks =
+		Boolean(hoveredProject) &&
+		revealedTaskProjectId === hoveredProject?.id &&
+		!hoveredProjectTaskLoading;
 	const hasProjectSelection = Boolean(selectedProjectId);
 
 	const loadProjectTasksIfNeeded = useCallback(
-		(projectId: string) => {
-			const project = projects.find((item) => item.id === projectId);
-			if (!project || !onLoadProjectTasks || loadingTaskProjectIds.has(projectId)) {
+		(projectId: string, session: number) => {
+			if (!onLoadProjectTasks || loadingTaskProjectIds.has(projectId)) {
 				return;
 			}
 			setLoadingTaskProjectIds((current) => new Set(current).add(projectId));
@@ -176,51 +221,117 @@ export function ProjectTaskPickerContent({
 					next.delete(projectId);
 					return next;
 				});
+				if (session !== hoverSessionRef.current) return;
+				setRevealedTaskProjectId(projectId);
 			});
 		},
-		[loadingTaskProjectIds, onLoadProjectTasks, projects],
+		[loadingTaskProjectIds, onLoadProjectTasks],
+	);
+
+	const hideHoveredProject = useCallback(() => {
+		beginHoverSession();
+		setHoveredSubmenu(null);
+		setSubmenuTop(0);
+		submenuRowRef.current = null;
+	}, [beginHoverSession]);
+
+	const openSubmenu = useCallback(
+		(row: HTMLElement, submenu: "new-project" | `project:${string}`, session: number) => {
+			const clip = listRoot?.contains(row) ? listRoot : null;
+			if (!isRowVisibleInClip(row, clip)) return;
+			const root = pickerRootRef.current;
+			submenuRowRef.current = row;
+			setHoveredSubmenu(submenu);
+			if (root) {
+				const rootRect = root.getBoundingClientRect();
+				const rowTop = row.getBoundingClientRect().top - rootRect.top;
+				const isProject = submenu.startsWith("project:");
+				const submenuHeight = estimateSubmenuHeightForFlip(submenu, 0, false, isProject);
+				setSubmenuTop(resolveSubmenuTop(rootRect, rowTop, submenuHeight));
+			}
+			if (submenu.startsWith("project:")) {
+				loadProjectTasksIfNeeded(submenu.slice("project:".length), session);
+			}
+		},
+		[listRoot, loadProjectTasksIfNeeded],
 	);
 
 	const showSubmenuAtRow = useCallback(
 		(row: HTMLElement, submenu: "new-project" | `project:${string}`) => {
 			if (submenu.startsWith("project:") && !allowSelectTask) {
-				setHoveredSubmenu(null);
-				setSubmenuTop(0);
-				submenuRowRef.current = null;
+				hideHoveredProject();
 				return;
 			}
-			const root = pickerRootRef.current;
+			if (hoveredSubmenu === submenu) return;
+			hideHoveredProject();
+			const session = hoverSessionRef.current;
 			submenuRowRef.current = row;
-			setHoveredSubmenu(submenu);
-			if (root) {
-				const projectId = submenu.startsWith("project:") ? submenu.slice("project:".length) : null;
-				const project = projectId ? projects.find((item) => item.id === projectId) : undefined;
-				const isLoadingTasks = projectId ? loadingTaskProjectIds.has(projectId) : false;
-				const rootRect = root.getBoundingClientRect();
-				const rowTop = row.getBoundingClientRect().top - rootRect.top;
-				const submenuHeight = estimateSubmenuHeightForFlip(submenu, project, isLoadingTasks);
-				setSubmenuTop(resolveSubmenuTop(rootRect, rowTop, submenuHeight));
-			}
-			if (submenu.startsWith("project:")) {
-				loadProjectTasksIfNeeded(submenu.slice("project:".length));
-			}
+			submenuTimerRef.current = window.setTimeout(() => {
+				submenuTimerRef.current = null;
+				if (session !== hoverSessionRef.current) return;
+				openSubmenu(row, submenu, session);
+			}, PROJECT_PICKER_HOVER_SUBMENU_MS);
 		},
-		[allowSelectTask, loadProjectTasksIfNeeded, loadingTaskProjectIds, projects],
+		[allowSelectTask, hideHoveredProject, hoveredSubmenu, openSubmenu],
 	);
+
+	useEffect(() => () => clearSubmenuTimer(), [clearSubmenuTimer]);
+
+	useEffect(() => {
+		if (!listRoot) return;
+		const onScroll = () => {
+			const row = submenuRowRef.current;
+			if (!row || !listRoot.contains(row)) return;
+			hideHoveredProject();
+			if (scrollSettleTimerRef.current != null) {
+				window.clearTimeout(scrollSettleTimerRef.current);
+			}
+			scrollSettleTimerRef.current = window.setTimeout(() => {
+				scrollSettleTimerRef.current = null;
+				const { x, y } = lastPointerRef.current;
+				const el = document.elementFromPoint(x, y);
+				if (!(el instanceof Element)) return;
+				const item = el.closest("[data-project-picker-item]");
+				if (!(item instanceof HTMLElement)) return;
+				const projectId = item.getAttribute("data-project-picker-item");
+				if (!projectId) return;
+				showSubmenuAtRow(item, `project:${projectId}`);
+			}, 80);
+		};
+		listRoot.addEventListener("scroll", onScroll, { passive: true });
+		return () => {
+			listRoot.removeEventListener("scroll", onScroll);
+			if (scrollSettleTimerRef.current != null) {
+				window.clearTimeout(scrollSettleTimerRef.current);
+			}
+		};
+	}, [hideHoveredProject, listRoot, showSubmenuAtRow]);
 
 	useEffect(() => {
 		const row = submenuRowRef.current;
 		const root = pickerRootRef.current;
 		if (!row || !root || !hoveredSubmenu) return;
+		if (listRoot?.contains(row) && !isRowVisibleInClip(row, listRoot)) {
+			hideHoveredProject();
+			return;
+		}
 
 		const projectId = hoveredSubmenu.startsWith("project:")
 			? hoveredSubmenu.slice("project:".length)
 			: null;
-		const project = projectId ? projects.find((item) => item.id === projectId) : undefined;
-		const isLoadingTasks = projectId ? loadingTaskProjectIds.has(projectId) : false;
+		const showTasks = projectId != null && revealedTaskProjectId === projectId;
+		const isLoading = projectId != null && loadingTaskProjectIds.has(projectId);
+		const taskCount = showTasks
+			? (projects.find((item) => item.id === projectId)?.tasks.length ?? 0)
+			: 0;
 		const rootRect = root.getBoundingClientRect();
 		const rowTop = row.getBoundingClientRect().top - rootRect.top;
-		const submenuHeight = estimateSubmenuHeightForFlip(hoveredSubmenu, project, isLoadingTasks);
+		const submenuHeight = estimateSubmenuHeightForFlip(
+			hoveredSubmenu,
+			taskCount,
+			showTasks,
+			isLoading,
+		);
 		setSubmenuTop(resolveSubmenuTop(rootRect, rowTop, submenuHeight));
 		// 中文注释：仅在切换 hover 目标时重算位置；任务列表刷新/首次加载只向下展开，避免 submenuTop 跳变导致底部抖动。
 	}, [hoveredSubmenu]);
@@ -238,13 +349,17 @@ export function ProjectTaskPickerContent({
 
 	const handleSearchChange = (value: string) => {
 		onSearchQueryChange(value);
-		setHoveredSubmenu(null);
-		setSubmenuTop(0);
-		submenuRowRef.current = null;
+		hideHoveredProject();
 	};
 
 	return (
-		<div ref={pickerRootRef} className="relative">
+		<div
+			ref={pickerRootRef}
+			className="relative"
+			onPointerMove={(event) => {
+				lastPointerRef.current = { x: event.clientX, y: event.clientY };
+			}}
+		>
 			<div className={PROJECT_PICKER_PANEL_CLASS}>
 				<Command
 					shouldFilter={false}
@@ -261,6 +376,7 @@ export function ProjectTaskPickerContent({
 					<div className="mt-1 mb-1">
 						<button
 							type="button"
+							data-project-picker-new=""
 							onMouseEnter={(event) => showSubmenuAtRow(event.currentTarget, "new-project")}
 							onClick={() => onSelectNewProject?.()}
 							className={projectPickerRowClass(!hasProjectSelection)}
@@ -273,13 +389,19 @@ export function ProjectTaskPickerContent({
 					</div>
 				) : null}
 				<div
-					ref={projectListRefCallback}
+					ref={(node) => {
+						setListRoot(node);
+						projectListRefCallback(node);
+					}}
 					className={cn(
 						PROJECT_PICKER_LIST_CLASS,
 						allowNewProject ? "border-t border-slate-100 pt-1" : "mt-1",
 					)}
 				>
-					{filteredProjects.map((project) => {
+					{listLoading && visibleProjects.length === 0 ? (
+						<div className="px-3 py-8 text-center text-sm text-slate-400">正在加载项目...</div>
+					) : null}
+					{visibleProjects.map((project) => {
 						const projectSelected = selectedProjectId === project.id;
 						return (
 							<button
@@ -303,8 +425,17 @@ export function ProjectTaskPickerContent({
 							</button>
 						);
 					})}
-					{filteredProjects.length === 0 ? (
+					{!listLoading && visibleProjects.length === 0 ? (
 						<div className="px-3 py-8 text-center text-sm text-slate-400">没有匹配的项目</div>
+					) : null}
+					{onLoadMore ? (
+						<ListLoadMoreSentinel
+							hasMore={listHasMore}
+							loading={listLoadingMore}
+							onLoadMore={onLoadMore}
+							root={listRoot}
+							className="py-2"
+						/>
 					) : null}
 				</div>
 			</div>
@@ -314,7 +445,10 @@ export function ProjectTaskPickerContent({
 					className={PROJECT_PICKER_SUBMENU_PANEL_CLASS}
 					style={{ top: submenuTop, maxHeight: PROJECT_PICKER_SUBMENU_MAX_HEIGHT_PX }}
 				>
-					<NewTaskPickerRow selected={!hasProjectSelection} onClick={() => onSelectNewProject?.()} />
+					<NewTaskPickerRow
+						selected={!hasProjectSelection}
+						onClick={() => onSelectNewProject?.()}
+					/>
 				</div>
 			) : null}
 
@@ -323,62 +457,48 @@ export function ProjectTaskPickerContent({
 					className={PROJECT_PICKER_SUBMENU_PANEL_CLASS}
 					style={{ top: submenuTop, maxHeight: PROJECT_PICKER_SUBMENU_MAX_HEIGHT_PX }}
 				>
-					<div className="relative">
-						<div className="space-y-1">
-							<NewTaskPickerRow
-								selected={selectedProjectId === hoveredProject.id && !selectedTaskId}
-								onClick={() => onSelectProject(hoveredProject)}
-							/>
-							{hoveredProjectTaskLoading && hoveredProject.tasks.length === 0 ? (
-								<div className={projectPickerPlaceholderRowClass()}>
-									<LoaderCircle className="size-4 shrink-0 animate-spin opacity-75" />
-									<span className="min-w-0 flex-1 truncate">任务加载中...</span>
-								</div>
-							) : hoveredProject.tasks.length > 0 ? (
-								<div className="relative space-y-1 border-t border-slate-100 pt-1">
-									<div
+					<NewTaskPickerRow
+						selected={selectedProjectId === hoveredProject.id && !selectedTaskId}
+						onClick={() => onSelectProject(hoveredProject)}
+					/>
+					{hoveredProjectTaskLoading ? (
+						<div className="space-y-1 border-t border-slate-100 pt-1">
+							<div className={projectPickerPlaceholderRowClass()}>
+								<LoaderCircle className="size-4 shrink-0 animate-spin opacity-75" />
+								<span className="min-w-0 flex-1 truncate">任务加载中...</span>
+							</div>
+						</div>
+					) : showHoveredProjectTasks && hoveredProject.tasks.length > 0 ? (
+						<div className="space-y-1 border-t border-slate-100 pt-1">
+							{hoveredProject.tasks.map((task) => {
+								const isResponding = task.runtimeStatus === "responding";
+								const selected =
+									!isResponding &&
+									selectedProjectId === hoveredProject.id &&
+									selectedTaskId === task.id;
+								return (
+									<button
+										key={task.id}
+										type="button"
+										disabled={isResponding}
+										onClick={() => onSelectTask(hoveredProject, task)}
 										className={cn(
-											"space-y-1",
-											hoveredProjectTaskLoading && "pointer-events-none",
+											projectPickerRowClass(selected),
+											isResponding && "cursor-not-allowed opacity-60",
 										)}
 									>
-										{hoveredProject.tasks.map((task) => {
-											const isResponding = task.runtimeStatus === "responding";
-											const selected =
-												!isResponding &&
-												selectedProjectId === hoveredProject.id &&
-												selectedTaskId === task.id;
-											return (
-												<button
-													key={task.id}
-													type="button"
-													disabled={isResponding}
-													onClick={() => onSelectTask(hoveredProject, task)}
-													className={cn(
-														projectPickerRowClass(selected),
-														isResponding && "cursor-not-allowed opacity-60",
-													)}
-												>
-													<ListTodo className="size-4 shrink-0 opacity-75" />
-													<span className="min-w-0 flex-1 truncate">{task.title}</span>
-													{isResponding ? (
-														<span className="shrink-0 text-xs text-slate-400">回复中</span>
-													) : (
-														selected && <Check className="size-4 shrink-0" />
-													)}
-												</button>
-											);
-										})}
-									</div>
-									{hoveredProjectTaskLoading ? (
-										<div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-white/80">
-											<LoaderCircle className="size-4 shrink-0 animate-spin text-slate-400" />
-										</div>
-									) : null}
-								</div>
-							) : null}
+										<ListTodo className="size-4 shrink-0 opacity-75" />
+										<span className="min-w-0 flex-1 truncate">{task.title}</span>
+										{isResponding ? (
+											<span className="shrink-0 text-xs text-slate-400">回复中</span>
+										) : (
+											selected && <Check className="size-4 shrink-0" />
+										)}
+									</button>
+								);
+							})}
 						</div>
-					</div>
+					) : null}
 				</div>
 			) : null}
 		</div>
@@ -386,7 +506,6 @@ export function ProjectTaskPickerContent({
 }
 
 export type ProjectTaskPickerFieldProps = {
-	projects: ProjectTaskPickerProject[];
 	projectId?: string | null;
 	taskId?: string | null;
 	disabled?: boolean;
@@ -400,7 +519,6 @@ export type ProjectTaskPickerFieldProps = {
 
 /** 中文注释：表单场景的项目/任务下拉，复用与工作台相同的选择面板。 */
 export function ProjectTaskPickerField({
-	projects,
 	projectId,
 	taskId,
 	disabled,
@@ -412,8 +530,13 @@ export function ProjectTaskPickerField({
 }: ProjectTaskPickerFieldProps) {
 	const [open, setOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const projectList = usePaginatedProjectList({
+		enabled: true,
+		keyword: searchQuery,
+	});
+	const cachedProjects = useLayoutStore((state) => state.projects);
 	const label = formatProjectTaskPickerLabel(
-		projects,
+		cachedProjects,
 		projectId,
 		allowSelectTask ? taskId : null,
 	);
@@ -451,7 +574,11 @@ export function ProjectTaskPickerField({
 					className="z-[70] !flex-none w-auto overflow-visible rounded-none border-0 bg-transparent p-0 shadow-none ring-0"
 				>
 					<ProjectTaskPickerContent
-						projects={projects}
+						projects={projectList.projects}
+						listLoading={projectList.loading}
+						hasMore={projectList.hasMore}
+						loadingMore={projectList.loadingMore}
+						onLoadMore={projectList.loadMore}
 						selectedProjectId={projectId}
 						selectedTaskId={allowSelectTask ? taskId : null}
 						searchQuery={searchQuery}

--- a/frontend/packages/app-ui/components/layout/WorkbenchPage.tsx
+++ b/frontend/packages/app-ui/components/layout/WorkbenchPage.tsx
@@ -341,7 +341,6 @@ export function WorkbenchPage({ navigation }: { navigation?: AppNavigation }) {
 
 					<div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-7 py-5">
 						<ProjectTaskPickerField
-							projects={projectOptions}
 							projectId={projectId}
 							taskId={taskId}
 							allowNewProject

--- a/frontend/packages/app-ui/components/layout/left-rail-list-utils.test.ts
+++ b/frontend/packages/app-ui/components/layout/left-rail-list-utils.test.ts
@@ -39,7 +39,7 @@ describe("getVisibleLeftRailItems", () => {
 });
 
 describe("getRecentProjectsForLeftRail", () => {
-	it("会返回全部项目并按更新时间倒序排列", () => {
+	it("会按更新时间倒序排列当前已加载的项目", () => {
 		const projects = [
 			{ id: "project-1", updatedAt: 100 },
 			{ id: "project-2", updatedAt: 90 },

--- a/frontend/packages/app-ui/components/layout/left-rail-list-utils.ts
+++ b/frontend/packages/app-ui/components/layout/left-rail-list-utils.ts
@@ -1,7 +1,7 @@
 export const LEFT_RAIL_LIST_PREVIEW_LIMIT = 6;
 
 export function getRecentProjectsForLeftRail<T extends { updatedAt: number }>(projects: T[]) {
-	// 中文注释：最近项目展示全量列表，按更新时间倒序排列。
+	// 中文注释：最近项目按更新时间倒序展示当前已加载分页，后续页由滚动懒加载补齐。
 	return [...projects].sort((a, b) => b.updatedAt - a.updatedAt);
 }
 

--- a/frontend/packages/app-ui/components/project/usePaginatedProjectList.ts
+++ b/frontend/packages/app-ui/components/project/usePaginatedProjectList.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import {
+	appendProjectsFromListResult,
+	fetchProjectListPage,
+	mergeProjectsFromListResult,
+	PROJECT_LIST_PAGE_SIZE,
+	type Project,
+	useLayoutStore,
+} from "@leros/store";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export function usePaginatedProjectList(options: {
+	enabled: boolean;
+	keyword?: string;
+	debounceMs?: number;
+	pageSize?: number;
+}) {
+	const { enabled, keyword = "", debounceMs = 300, pageSize = PROJECT_LIST_PAGE_SIZE } = options;
+	const upsertProjects = useLayoutStore((state) => state.upsertProjects);
+	const mutationEpoch = useLayoutStore((state) => state.projectsMutationEpoch);
+	const projectCache = useLayoutStore((state) => state.projects);
+
+	const [debouncedKeyword, setDebouncedKeyword] = useState(keyword.trim());
+	const [items, setItems] = useState<Project[]>([]);
+	const [total, setTotal] = useState(0);
+	const [nextOffset, setNextOffset] = useState(0);
+	const [hasMore, setHasMore] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [loadingMore, setLoadingMore] = useState(false);
+
+	useEffect(() => {
+		if (debounceMs <= 0) {
+			setDebouncedKeyword(keyword.trim());
+			return;
+		}
+		const timer = window.setTimeout(() => {
+			setDebouncedKeyword(keyword.trim());
+		}, debounceMs);
+		return () => window.clearTimeout(timer);
+	}, [debounceMs, keyword]);
+
+	useEffect(() => {
+		if (!enabled) {
+			setItems([]);
+			setTotal(0);
+			setNextOffset(0);
+			setHasMore(false);
+			setLoading(false);
+			setLoadingMore(false);
+			return;
+		}
+
+		let cancelled = false;
+		setLoading(true);
+		void fetchProjectListPage({
+			keyword: debouncedKeyword || undefined,
+			offset: 0,
+			limit: pageSize,
+		})
+			.then((page) => {
+				if (cancelled) return;
+				upsertProjects(page.items);
+				setItems(page.items);
+				setTotal(page.total);
+				setNextOffset(page.items.length);
+				setHasMore(page.hasMore);
+			})
+			.catch((error) => {
+				if (cancelled) return;
+				console.error("usePaginatedProjectList error:", error);
+				setItems([]);
+				setTotal(0);
+				setNextOffset(0);
+				setHasMore(false);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [debouncedKeyword, enabled, mutationEpoch, pageSize, upsertProjects]);
+
+	const loadMore = useCallback(() => {
+		if (!enabled || loading || loadingMore || !hasMore) return;
+		setLoadingMore(true);
+		void fetchProjectListPage({
+			keyword: debouncedKeyword || undefined,
+			offset: nextOffset,
+			limit: pageSize,
+		})
+			.then((page) => {
+				upsertProjects(page.items);
+				setItems((current) => appendProjectsFromListResult(page.items, current));
+				setNextOffset((current) => current + page.items.length);
+				setHasMore(page.hasMore);
+				setTotal(page.total);
+			})
+			.catch((error) => {
+				console.error("usePaginatedProjectList load more error:", error);
+			})
+			.finally(() => {
+				setLoadingMore(false);
+			});
+	}, [
+		debouncedKeyword,
+		enabled,
+		hasMore,
+		loading,
+		loadingMore,
+		nextOffset,
+		pageSize,
+		upsertProjects,
+	]);
+
+	const projects = useMemo(
+		() => mergeProjectsFromListResult(items, projectCache),
+		[items, projectCache],
+	);
+
+	return {
+		projects,
+		total,
+		hasMore,
+		loading,
+		loadingMore,
+		loadMore,
+	};
+}

--- a/frontend/packages/store/index.ts
+++ b/frontend/packages/store/index.ts
@@ -291,6 +291,7 @@ export type {
 	NavItem,
 	Project,
 	ProjectArtifact,
+	ProjectListPage,
 	ProjectMember,
 	ProjectMemberType,
 	ProjectMessage,
@@ -304,9 +305,14 @@ export type {
 	WorkspaceMode,
 } from "./slices/layoutSlice";
 export {
+	appendProjectsFromListResult,
+	fetchProjectListPage,
 	LEFT_RAIL_MAX_WIDTH,
 	LEFT_RAIL_MIN_WIDTH,
+	mergeProjectsFromListResult,
+	PROJECT_LIST_PAGE_SIZE,
 	projectMembersToInputs,
+	upsertProjectsIntoCache,
 } from "./slices/layoutSlice";
 export type { ModelAction, ModelItem, ModelState, ModelStore } from "./slices/modelSlice";
 export {

--- a/frontend/packages/store/slices/layoutSlice.test.ts
+++ b/frontend/packages/store/slices/layoutSlice.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { projectApi } from "../api/projectApi";
+import * as authStorage from "../utils/authStorage";
 import type { Project, ProjectMember } from "./layoutSlice";
-import { LayoutActionImpl, mergeProjectsFromListResult } from "./layoutSlice";
+import {
+	appendProjectsFromListResult,
+	LayoutActionImpl,
+	mergeProjectsFromListResult,
+	PROJECT_LIST_PAGE_SIZE,
+	upsertProjectsIntoCache,
+} from "./layoutSlice";
 
 function createProject(
 	overrides: Partial<Project> & Pick<Project, "id" | "name" | "updatedAt">,
@@ -83,6 +90,36 @@ describe("mergeProjectsFromListResult", () => {
 		const mergedProjects = mergeProjectsFromListResult(apiProjects, localProjects);
 
 		expect(mergedProjects.map((project) => project.id)).toEqual(["project-1"]);
+	});
+});
+
+describe("appendProjectsFromListResult", () => {
+	it("追加分页时保留已加载项目，并跳过重复 id", () => {
+		const localProjects = [
+			createProject({
+				id: "project-1",
+				name: "已加载",
+				updatedAt: 20,
+				tasks: [{ id: "task-1", title: "任务 1", meta: "", status: "todo" }],
+			}),
+		];
+		const apiProjects = [
+			createProject({
+				id: "project-1",
+				name: "重复项",
+				updatedAt: 30,
+			}),
+			createProject({
+				id: "project-2",
+				name: "下一页",
+				updatedAt: 10,
+			}),
+		];
+
+		const mergedProjects = appendProjectsFromListResult(apiProjects, localProjects);
+
+		expect(mergedProjects.map((project) => project.id)).toEqual(["project-1", "project-2"]);
+		expect(mergedProjects[0]?.tasks.map((task) => task.id)).toEqual(["task-1"]);
 	});
 });
 
@@ -247,5 +284,72 @@ describe("LayoutActionImpl.sendWorkbenchMessage", () => {
 		);
 		expect(bootstrapNewTaskSession).not.toHaveBeenCalled();
 		expect(loadConversationMessages).toHaveBeenCalledBefore(sendTaskRoomMessage);
+	});
+});
+
+describe("upsertProjectsIntoCache", () => {
+	it("写入实体缓存时保留未出现在本页的本地项目", () => {
+		const localProjects = [
+			createProject({ id: "project-local", name: "本地项目", updatedAt: 5 }),
+			createProject({
+				id: "project-1",
+				name: "旧名称",
+				updatedAt: 10,
+				tasks: [{ id: "task-1", title: "任务 1", meta: "", status: "todo" }],
+			}),
+		];
+		const incoming = [
+			createProject({
+				id: "project-1",
+				name: "新名称",
+				updatedAt: 20,
+			}),
+		];
+
+		const cached = upsertProjectsIntoCache(incoming, localProjects);
+
+		expect(cached.map((project) => project.id)).toEqual(["project-1", "project-local"]);
+		expect(cached[0]?.name).toBe("新名称");
+		expect(cached[0]?.tasks.map((task) => task.id)).toEqual(["task-1"]);
+	});
+});
+
+describe("LayoutActionImpl.fetchProjects", () => {
+	it("只请求第一页写入实体缓存，并保留未出现在本页的本地项目", async () => {
+		vi.spyOn(authStorage, "readStoredAuthUser").mockReturnValue({ jwtToken: "token" } as never);
+		const list = vi.spyOn(projectApi, "list").mockResolvedValue({
+			data: {
+				code: 0,
+				message: "ok",
+				data: {
+					total: 45,
+					items: Array.from({ length: PROJECT_LIST_PAGE_SIZE }, (_, index) => ({
+						public_id: `project-${index + 1}`,
+						name: `project-${index + 1}`,
+						created_at: "2026-01-01T00:00:00Z",
+						updated_at: "2026-01-01T00:00:00Z",
+					})),
+				},
+			},
+		} as never);
+		const state = {
+			projects: [createProject({ id: "project-local", name: "本地项目", updatedAt: 1 })],
+			projectsMutationEpoch: 0,
+		};
+		const setState = (partial: unknown) => {
+			const update =
+				typeof partial === "function"
+					? (partial as (current: typeof state) => Partial<typeof state>)(state)
+					: (partial as Partial<typeof state>);
+			Object.assign(state, update);
+		};
+		const actions = new LayoutActionImpl(setState as never, (() => state) as never);
+
+		await expect(actions.fetchProjects()).resolves.toBe(true);
+
+		expect(list).toHaveBeenCalledTimes(1);
+		expect(list).toHaveBeenCalledWith({ offset: 0, limit: PROJECT_LIST_PAGE_SIZE });
+		expect(state.projects).toHaveLength(PROJECT_LIST_PAGE_SIZE + 1);
+		expect(state.projects.some((project) => project.id === "project-local")).toBe(true);
 	});
 });

--- a/frontend/packages/store/slices/layoutSlice.ts
+++ b/frontend/packages/store/slices/layoutSlice.ts
@@ -225,7 +225,10 @@ export type LayoutState = {
 	activeWorkbenchTaskId: string | null;
 	activeProjectTab: ProjectTab;
 	workspaces: Workspace[];
+	/** 已打开/列表触及过的项目实体缓存，不是任何 UI 的完整列表。 */
 	projects: Project[];
+	/** 创建/删除/离开/切组织后递增，驱动各列表独立重新拉第一页。 */
+	projectsMutationEpoch: number;
 	inputFocused: boolean;
 	activeRightTab: "shortcuts" | "inbox" | "artifacts";
 	navGroups: NavGroup[];
@@ -246,6 +249,16 @@ export type LayoutState = {
 
 export type LayoutAction = Pick<LayoutActionImpl, keyof LayoutActionImpl>;
 export type LayoutStore = LayoutState & LayoutAction;
+
+/** 各项目列表/选择器独立分页时的默认页大小。 */
+export const PROJECT_LIST_PAGE_SIZE = 20;
+
+export type ProjectListPage = {
+	items: Project[];
+	total: number;
+	offset: number;
+	hasMore: boolean;
+};
 
 function mapBackendProject(bp: BackendProject): Project {
 	const metadata = bp.metadata ?? undefined;
@@ -292,8 +305,48 @@ export function mergeProjectsFromListResult(
 		};
 	});
 
-	// 中文注释：列表接口已按分页拉取完整项目集，因此这里只保留接口中仍存在的项目，避免已删除项目继续残留在本地状态里。
+	// 中文注释：首页刷新只覆盖本页结果；未出现在本页的本地项目由调用方决定是否丢弃。
 	return mergedApiProjects;
+}
+
+export function appendProjectsFromListResult(
+	apiProjects: Project[],
+	localProjects: Project[],
+): Project[] {
+	const localIds = new Set(localProjects.map((project) => project.id));
+	const mergedPage = mergeProjectsFromListResult(apiProjects, localProjects);
+	const appended = mergedPage.filter((project) => !localIds.has(project.id));
+	return [...localProjects, ...appended];
+}
+
+export function upsertProjectsIntoCache(incoming: Project[], localProjects: Project[]): Project[] {
+	const mergedIncoming = mergeProjectsFromListResult(incoming, localProjects);
+	const incomingIds = new Set(mergedIncoming.map((project) => project.id));
+	const keptLocal = localProjects.filter((project) => !incomingIds.has(project.id));
+	return [...mergedIncoming, ...keptLocal];
+}
+
+export async function fetchProjectListPage(params: {
+	keyword?: string;
+	offset?: number;
+	limit?: number;
+}): Promise<ProjectListPage> {
+	const offset = params.offset ?? 0;
+	const limit = params.limit ?? PROJECT_LIST_PAGE_SIZE;
+	const res = await projectApi.list({
+		keyword: params.keyword,
+		offset,
+		limit,
+	});
+	const data = res.data.data;
+	const items = (data?.items ?? []).map(mapBackendProject);
+	const total = data?.total ?? 0;
+	return {
+		items,
+		total,
+		offset,
+		hasMore: offset + items.length < total && items.length > 0,
+	};
 }
 
 function mapBackendProjectMember(member: BackendProjectMemberItem): ProjectMember {
@@ -467,6 +520,7 @@ const _initialState: LayoutState = {
 		{ id: "local-1", name: "本地工作区", mode: "local", collapsed: false },
 	],
 	projects: [],
+	projectsMutationEpoch: 0,
 	inputFocused: false,
 	activeRightTab: "shortcuts",
 	navGroups: [
@@ -845,30 +899,9 @@ export class LayoutActionImpl {
 		this.#fetchProjectsPromise = (async () => {
 			let succeeded = false;
 			try {
-				const pageSize = 100;
-				let offset = 0;
-				let total = Number.POSITIVE_INFINITY;
-				const items: BackendProject[] = [];
-
-				// 中文注释：多个页面壳会同时请求项目列表，复用同一个分页拉取流程，避免刷新时重复打 ListProjects。
-				while (offset < total) {
-					const res = await projectApi.list({ offset, limit: pageSize });
-					const data = res.data.data;
-					const pageItems = data?.items ?? [];
-					total = data?.total ?? 0;
-					items.push(...pageItems);
-					if (pageItems.length === 0) break;
-					offset += pageItems.length;
-				}
-
+				const page = await fetchProjectListPage({ offset: 0, limit: PROJECT_LIST_PAGE_SIZE });
 				if (fetchEpoch !== this.#projectsFetchEpoch) return false;
-
-				const apiProjects = items.map(mapBackendProject);
-				this.#set((state) => ({
-					projects: apiProjects.length
-						? mergeProjectsFromListResult(apiProjects, state.projects)
-						: [],
-				}));
+				this.upsertProjects(page.items);
 				succeeded = true;
 			} catch (err) {
 				console.error("fetchProjects error:", err);
@@ -883,6 +916,13 @@ export class LayoutActionImpl {
 		return this.#fetchProjectsPromise;
 	};
 
+	upsertProjects = (incoming: Project[]) => {
+		if (incoming.length === 0) return;
+		this.#set((state) => ({
+			projects: upsertProjectsIntoCache(incoming, state.projects),
+		}));
+	};
+
 	createProject = async (params: {
 		name: string;
 		description?: string;
@@ -895,7 +935,8 @@ export class LayoutActionImpl {
 			if (!bp) throw new Error("No data returned");
 			const item = mapBackendProject(bp);
 			this.#set((state) => ({
-				projects: [item, ...state.projects],
+				projects: [item, ...state.projects.filter((project) => project.id !== item.id)],
+				projectsMutationEpoch: state.projectsMutationEpoch + 1,
 			}));
 			return item;
 		} catch (err) {
@@ -962,6 +1003,7 @@ export class LayoutActionImpl {
 					state.activeWorkbenchProjectId === publicId ? null : state.activeWorkbenchProjectId,
 				activeWorkbenchTaskId:
 					state.activeWorkbenchProjectId === publicId ? null : state.activeWorkbenchTaskId,
+				projectsMutationEpoch: state.projectsMutationEpoch + 1,
 			}));
 			return true;
 		} catch (err) {
@@ -987,6 +1029,7 @@ export class LayoutActionImpl {
 					state.activeTaskDetailProjectId === publicId ? null : state.activeTaskDetailTaskId,
 				activeTaskDetailSessionId:
 					state.activeTaskDetailProjectId === publicId ? null : state.activeTaskDetailSessionId,
+				projectsMutationEpoch: state.projectsMutationEpoch + 1,
 			}));
 			const store = this.#get() as LayoutStore & {
 				invalidate?: (resource?: { type: "project"; publicId: string }) => void;
@@ -1001,30 +1044,32 @@ export class LayoutActionImpl {
 	};
 
 	fetchTasks = async (projectId: string) => {
-		const project = this.#get().projects.find((p) => p.id === projectId);
-		if (!project) return;
-
 		try {
 			const res = await projectApi.detail({ public_id: projectId });
 			const detail = res.data.data;
 			if (!detail) throw new Error("No data returned");
+			const mapped = mapBackendProject(detail);
 			const tasks = (detail.tasks ?? []).map(mapBackendTask);
-			this.#set((s) => ({
-				projects: s.projects.map((p) =>
-					p.id === projectId
-						? {
-								...p,
-								name: formatTaskDisplayTitle(detail.name),
-								description: detail.description ?? "",
-								objective: detail.objective,
-								updatedAt: new Date(detail.updated_at).getTime(),
-								tasks,
-							}
-						: p,
-				),
-				projectSessionId: detail.session?.session_id ?? s.projectSessionId,
-				projectSessionProjectId: detail.session?.session_id ? projectId : s.projectSessionProjectId,
-			}));
+			this.#set((s) => {
+				const exists = s.projects.some((p) => p.id === projectId);
+				const nextProject = {
+					...(s.projects.find((p) => p.id === projectId) ?? mapped),
+					name: formatTaskDisplayTitle(detail.name),
+					description: detail.description ?? "",
+					objective: detail.objective,
+					updatedAt: new Date(detail.updated_at).getTime(),
+					tasks,
+				};
+				return {
+					projects: exists
+						? s.projects.map((p) => (p.id === projectId ? nextProject : p))
+						: [nextProject, ...s.projects],
+					projectSessionId: detail.session?.session_id ?? s.projectSessionId,
+					projectSessionProjectId: detail.session?.session_id
+						? projectId
+						: s.projectSessionProjectId,
+				};
+			});
 		} catch (err) {
 			console.error("fetchTasks error:", err);
 		}
@@ -1296,6 +1341,7 @@ export class LayoutActionImpl {
 			activeWorkbenchTaskId: null,
 			activeProjectTab: "chat",
 			projects: [],
+			projectsMutationEpoch: this.#get().projectsMutationEpoch + 1,
 			activeTaskDetailProjectId: null,
 			activeTaskDetailTaskId: null,
 			activeTaskDetailSessionId: null,


### PR DESCRIPTION
- 最近项目、项目中心、选择器等各自独立分页加载，避免一次拉全量或互相抢缓存
- 悬停满 0.5s 才展示右侧任务菜单，出现后立即拉任务；掠过不弹出、不打接口