### PR TITLE
fix(upload): 将单文件上传上限从 100MB 调整为 500MB

### DIFF
--- a/backend/internal/service/file_service.go
+++ b/backend/internal/service/file_service.go
@@ -30,7 +30,7 @@ func NewFileService(db *gorm.DB) contract.FileService {
 	return &fileService{db: db}
 }
 
-const maxUploadSize = 100 << 20 // 100MB
+const maxUploadSize = 500 << 20 // 500MB
 
 func (s *fileService) UploadFile(ctx context.Context, req *contract.UploadFileRequest) (*contract.UploadFileResult, error) {
 	caller, err := requireCallerOrg(ctx)


### PR DESCRIPTION
- 后端 UploadFile 原先按 100MB 拒绝超大文件，大附件无法上传
- 将 maxUploadSize 调整为 500MB，与文件夹上传合计上限对齐