### PR TITLE
refactor(file): 文件上传链路整体流式化，避免大文件整读内存

### DIFF
--- a/backend/internal/api/contract/file.go
+++ b/backend/internal/api/contract/file.go
@@ -17,7 +17,6 @@ type UploadFileRequest struct {
 	OwnerID      uint
 	File         io.Reader
 	Filename     string
-	FileSize     int64
 	MimeType     string
 	Purpose      string
 	SourceID     string

--- a/backend/internal/api/handler/file_handler.go
+++ b/backend/internal/api/handler/file_handler.go
@@ -1,9 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -36,37 +39,24 @@ func (h *FileHandler) RegisterAnonymousRoutes(r gin.IRouter) {
 }
 
 // @Summary 上传文件
-// @Description 上传文件到系统
+// @Description 上传文件到系统。请求体以 multipart/form-data 流式解析，purpose/source_id/local-path 等表单字段必须位于 file part 之前，file 之后的字段不会被读取。
 // @Tags File
 // @Accept multipart/form-data
 // @Produce json
-// @Param file formData file true "上传文件"
-// @Param purpose formData string false "文件用途（默认 attachment）"
-// @Param source_id formData string false "来源ID（可选）"
+// @Param file formData file true "文件（须为最后一个 form part）"
+// @Param purpose formData string false "文件用途（默认 attachment；须在 file part 之前）"
+// @Param source_id formData string false "来源ID（可选；须在 file part 之前）"
+// @Param local-path formData string false "本地路径（composer 上传用，可选；须在 file part 之前）"
 // @Success 200 {object} dto.Response "上传成功"
 // @Failure 400 {object} dto.ErrorResponse "请求参数错误"
 // @Failure 401 {object} dto.ErrorResponse "未认证"
 // @Router /files/upload [post]
 func (h *FileHandler) UploadFile(ctx *gin.Context) {
-	fileHeader, err := ctx.FormFile("file")
+	mr, err := ctx.Request.MultipartReader()
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "file is required"))
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "invalid multipart request"))
 		return
 	}
-
-	purpose := strings.TrimSpace(ctx.PostForm("purpose"))
-	if purpose == "" {
-		purpose = filestore.PurposeAttachment
-	}
-
-	sourceID := strings.TrimSpace(ctx.PostForm("source_id"))
-
-	file, err := fileHeader.Open()
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, dto.Error(dto.CodeInternalError, "failed to open file"))
-		return
-	}
-	defer file.Close()
 
 	caller, _ := auth.FromGinContext(ctx)
 	if caller == nil || caller.OrgID == 0 {
@@ -74,34 +64,145 @@ func (h *FileHandler) UploadFile(ctx *gin.Context) {
 		return
 	}
 
-	localPath := strings.TrimSpace(ctx.PostForm("local-path"))
+	purpose := filestore.PurposeAttachment
+	var sourceID, localPath string
+	var filePart *multipart.Part
+
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "invalid multipart request"))
+			return
+		}
+		switch part.FormName() {
+		case "file":
+			// file 必须作为最后一个有效 part：请求体是单遍流式解析，
+			// 一旦命中 file 就停止读字段（继续 NextPart 会排空 file 内容），
+			// 其后的任何字段都不会生效，仅在上传成功后整体排空。
+			filePart = part
+		case "purpose":
+			v, err := readMultipartField(part, 64)
+			if err != nil {
+				ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "invalid multipart request"))
+				return
+			}
+			if v != "" {
+				purpose = v
+			}
+		case "source_id":
+			v, err := readMultipartField(part, 256)
+			if err != nil {
+				ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "invalid multipart request"))
+				return
+			}
+			sourceID = v
+		case "local-path":
+			v, err := readMultipartField(part, 1024)
+			if err != nil {
+				ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "invalid multipart request"))
+				return
+			}
+			localPath = v
+		default:
+			io.Copy(io.Discard, part)
+		}
+		if filePart != nil {
+			break
+		}
+	}
+
+	if filePart == nil {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeInvalidParams, "file is required"))
+		return
+	}
+
+	// purpose/source_id 会拼入对象存储 key 的路径段，限制字符集与长度，
+	// 避免破坏 key 结构（路径分隔符、".." 等），给出明确的 4xx 而不是底层 500。
+	if !validKeySegment(purpose) {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeValidationError, "invalid purpose"))
+		return
+	}
+	if sourceID != "" && !validKeySegment(sourceID) {
+		ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeValidationError, "invalid source_id"))
+		return
+	}
+
 	if localPath != "" {
 		if err := filestore.ValidateComposerUploadFilename(localPath); err != nil {
 			ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeValidationError, "unsupported file type"))
 			return
 		}
-		if fileHeader.Size == 0 {
-			ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeValidationError, "empty file is not allowed"))
-			return
-		}
 	}
 
 	result, err := h.service.UploadFile(ctx, &contract.UploadFileRequest{
-		OrgID:    caller.OrgID,
-		OwnerID:  caller.Uin,
-		File:     file,
-		Filename: fileHeader.Filename,
-		FileSize: fileHeader.Size,
-		MimeType: fileHeader.Header.Get("Content-Type"),
-		Purpose:  purpose,
-		SourceID: sourceID,
+		OrgID:        caller.OrgID,
+		OwnerID:      caller.Uin,
+		File:         filePart,
+		Filename:     filePart.FileName(),
+		MimeType:     filePart.Header.Get("Content-Type"),
+		Purpose:      purpose,
+		SourceID:     sourceID,
+		RelativePath: localPath,
 	})
 	if err != nil {
+		if errors.Is(err, filestore.ErrUploadTooLarge) {
+			ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeValidationError, "file size exceeds maximum allowed size"))
+			return
+		}
+		if errors.Is(err, filestore.ErrEmptyFile) {
+			ctx.JSON(http.StatusBadRequest, dto.Error(dto.CodeValidationError, "empty file is not allowed"))
+			return
+		}
 		ctx.JSON(http.StatusInternalServerError, dto.Error(dto.CodeInternalError, "upload file failed"))
 		return
 	}
 
+	drainMultipartReader(mr)
+
 	ctx.JSON(http.StatusOK, dto.Success(result))
+}
+
+func readMultipartField(part *multipart.Part, maxLen int) (string, error) {
+	b, err := io.ReadAll(io.LimitReader(part, int64(maxLen+1)))
+	if err != nil {
+		return "", err
+	}
+	if len(b) > maxLen {
+		return "", errMultipartFieldTooLarge
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// errMultipartFieldTooLarge 表示 multipart 文本字段超过允许的最大长度。
+var errMultipartFieldTooLarge = errors.New("multipart form field too large")
+
+// keySegmentRe 允许的 multipart 字段字符集（字母数字及 _.-，用于拼入对象存储 key 的路径段）。
+var keySegmentRe = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+// validKeySegment 校验将拼入对象存储 key 的字段值（purpose / source_id），
+// 拒绝路径分隔符、空白、".." 及超长输入。
+func validKeySegment(s string) bool {
+	if s == "" || len(s) > 64 {
+		return false
+	}
+	if strings.Contains(s, "..") {
+		return false
+	}
+	return keySegmentRe.MatchString(s)
+}
+
+// drainMultipartReader 消费 multipart 剩余内容，保证请求体被完整读取、连接可复用。
+func drainMultipartReader(mr *multipart.Reader) {
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			return
+		}
+		io.Copy(io.Discard, part)
+	}
 }
 
 // @Summary 下载文件

--- a/backend/internal/api/handler/file_handler_gin_test.go
+++ b/backend/internal/api/handler/file_handler_gin_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/insmtx/Leros/backend/internal/api/auth"
 	"github.com/insmtx/Leros/backend/internal/api/contract"
 	"github.com/insmtx/Leros/backend/internal/api/dto"
+	"github.com/insmtx/Leros/backend/internal/infra/filestore"
 	"github.com/insmtx/Leros/backend/types"
 )
 
@@ -216,6 +217,132 @@ func TestUploadFile_ServiceError(t *testing.T) {
 	}
 }
 
+func TestUploadFile_TooLargeMappedTo400(t *testing.T) {
+	svc := &mockFileService{
+		uploadFn: func(ctx context.Context, req *contract.UploadFileRequest) (*contract.UploadFileResult, error) {
+			return nil, filestore.ErrUploadTooLarge
+		},
+	}
+	router := setupFileRouter(t, svc, authenticatedCaller())
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	part, _ := w.CreateFormFile("file", "test.txt")
+	part.Write([]byte("hello"))
+	w.Close()
+
+	req := httptest.NewRequest("POST", "/v1/files/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized upload, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUploadFile_EmptyMappedTo400(t *testing.T) {
+	svc := &mockFileService{
+		uploadFn: func(ctx context.Context, req *contract.UploadFileRequest) (*contract.UploadFileResult, error) {
+			return nil, filestore.ErrEmptyFile
+		},
+	}
+	router := setupFileRouter(t, svc, authenticatedCaller())
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	part, _ := w.CreateFormFile("file", "test.txt")
+	part.Write([]byte("hello"))
+	w.Close()
+
+	req := httptest.NewRequest("POST", "/v1/files/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty upload, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUploadFile_InvalidPurpose(t *testing.T) {
+	svc := &mockFileService{
+		uploadFn: func(ctx context.Context, req *contract.UploadFileRequest) (*contract.UploadFileResult, error) {
+			t.Error("upload should not be called with invalid purpose")
+			return nil, nil
+		},
+	}
+	router := setupFileRouter(t, svc, authenticatedCaller())
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	_ = w.WriteField("purpose", "../avatar")
+	part, _ := w.CreateFormFile("file", "test.png")
+	part.Write([]byte("image data"))
+	w.Close()
+
+	req := httptest.NewRequest("POST", "/v1/files/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid purpose, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUploadFile_InvalidSourceID(t *testing.T) {
+	svc := &mockFileService{
+		uploadFn: func(ctx context.Context, req *contract.UploadFileRequest) (*contract.UploadFileResult, error) {
+			t.Error("upload should not be called with invalid source_id")
+			return nil, nil
+		},
+	}
+	router := setupFileRouter(t, svc, authenticatedCaller())
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	_ = w.WriteField("source_id", "a/b")
+	part, _ := w.CreateFormFile("file", "test.png")
+	part.Write([]byte("image data"))
+	w.Close()
+
+	req := httptest.NewRequest("POST", "/v1/files/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid source_id, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUploadFile_FieldTooLong(t *testing.T) {
+	svc := &mockFileService{
+		uploadFn: func(ctx context.Context, req *contract.UploadFileRequest) (*contract.UploadFileResult, error) {
+			t.Error("upload should not be called with oversized field")
+			return nil, nil
+		},
+	}
+	router := setupFileRouter(t, svc, authenticatedCaller())
+
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	_ = w.WriteField("purpose", strings.Repeat("a", 100)) // 超过 64 字节上限
+	part, _ := w.CreateFormFile("file", "test.png")
+	part.Write([]byte("image data"))
+	w.Close()
+
+	req := httptest.NewRequest("POST", "/v1/files/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized field, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestDownloadFile_NoFileID(t *testing.T) {
 	svc := &mockFileService{
 		downloadFn: func(ctx context.Context, orgID uint, fileID string) (io.ReadCloser, *contract.FileDownloadInfo, error) {
@@ -396,7 +523,7 @@ func TestDownloadFile_InvalidFileOpen(t *testing.T) {
 	part.Write([]byte("hello"))
 	w.Close()
 
-	truncated := bytes.NewReader(body.Bytes()[:len(body.Bytes())-50])
+	truncated := bytes.NewReader(body.Bytes()[:20]) // 截断到 part header 之前，NextPart 无法读到有效 part。
 	req := httptest.NewRequest("POST", "/v1/files/upload", truncated)
 	req.Header.Set("Content-Type", w.FormDataContentType())
 	rec := httptest.NewRecorder()

--- a/backend/internal/infra/filestore/upload.go
+++ b/backend/internal/infra/filestore/upload.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -105,9 +106,116 @@ func Upload(ctx context.Context, db *gorm.DB, params UploadParams) (*types.FileU
 	}
 
 	if err := infradb.CreateFileUpload(ctx, db, fileUpload); err != nil {
+		// 对象已写入存储但记录创建失败，尽力清理，避免残留孤儿对象。
+		if derr := st.DeleteObject(ctx, DefaultBucket(), params.ObjectKey); derr != nil {
+			return nil, fmt.Errorf("create file upload record: %w (cleanup object failed: %v)", err, derr)
+		}
 		return nil, fmt.Errorf("create file upload record: %w", err)
 	}
 	return fileUpload, nil
+}
+
+// ErrUploadTooLarge 表示上传文件超过允许的最大大小。
+var ErrUploadTooLarge = errors.New("file size exceeds maximum allowed size")
+
+// ErrEmptyFile 表示上传了空文件。
+var ErrEmptyFile = errors.New("empty file is not allowed")
+
+// UploadStreamParams 流式上传参数。
+type UploadStreamParams struct {
+	Filename     string
+	OriginalName string
+	MimeType     string
+	OwnerScope   types.OwnerScope
+	OrgID        uint
+	OwnerID      uint
+	ObjectKey    string
+	Purpose      string
+	Metadata     map[string]interface{}
+}
+
+// UploadStream 以流式方式写入 filestore 并同时计算 sha256，避免将整个文件读入内存。
+// 数据经固定大小的缓冲从 reader 直接流向对象存储；当写入字节数超过 maxSize 或
+// 文件为空时，会清理已写入对象并返回 ErrUploadTooLarge / ErrEmptyFile。
+func UploadStream(ctx context.Context, db *gorm.DB, params UploadStreamParams, reader io.Reader, maxSize int64) (*types.FileUpload, error) {
+	if params.Filename == "" {
+		return nil, fmt.Errorf("filename is required")
+	}
+	if params.MimeType == "" {
+		return nil, fmt.Errorf("mime type is required")
+	}
+	if params.ObjectKey == "" {
+		return nil, fmt.Errorf("object key is required")
+	}
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("max size must be positive")
+	}
+	params.OwnerScope = types.NormalizeOwnerScope(params.OwnerScope)
+	if err := validateOwner(params.OwnerScope, params.OrgID, params.OwnerID); err != nil {
+		return nil, err
+	}
+
+	counting := &countingReader{r: reader}
+	hasher := sha256.New()
+	st := GetStorage()
+	putResult, err := st.PutObject(ctx, DefaultBucket(), params.ObjectKey,
+		io.TeeReader(io.LimitReader(counting, maxSize+1), hasher),
+		storage.WithContentType(params.MimeType),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("put object: %w", err)
+	}
+	if counting.n > maxSize {
+		_ = st.DeleteObject(ctx, DefaultBucket(), params.ObjectKey)
+		return nil, ErrUploadTooLarge
+	}
+	if counting.n == 0 {
+		_ = st.DeleteObject(ctx, DefaultBucket(), params.ObjectKey)
+		return nil, ErrEmptyFile
+	}
+
+	publicID := GenerateFilePublicID()
+	originalName := params.OriginalName
+	if originalName == "" {
+		originalName = params.Filename
+	}
+	fileUpload := &types.FileUpload{
+		PublicID:     publicID,
+		OwnerScope:   params.OwnerScope,
+		OrgID:        params.OrgID,
+		OwnerID:      params.OwnerID,
+		Filename:     params.Filename,
+		OriginalName: originalName,
+		MimeType:     params.MimeType,
+		FileSize:     counting.n,
+		StorageURI:   putResult.Path.URI(),
+		Sha256:       hex.EncodeToString(hasher.Sum(nil)),
+		Purpose:      params.Purpose,
+		Status:       "active",
+		Metadata: types.ObjectMetadata{
+			Extra: params.Metadata,
+		},
+	}
+
+	if err := infradb.CreateFileUpload(ctx, db, fileUpload); err != nil {
+		// 对象已写入存储但记录创建失败，尽力清理，避免残留孤儿对象。
+		if derr := st.DeleteObject(ctx, DefaultBucket(), params.ObjectKey); derr != nil {
+			return nil, fmt.Errorf("create file upload record: %w (cleanup object failed: %v)", err, derr)
+		}
+		return nil, fmt.Errorf("create file upload record: %w", err)
+	}
+	return fileUpload, nil
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
 }
 
 // OpenFileByPublicID 通过 FileUpload.PublicID 从 filestore 打开文件流

--- a/backend/internal/infra/filestore/upload_stream_test.go
+++ b/backend/internal/infra/filestore/upload_stream_test.go
@@ -1,0 +1,215 @@
+package filestore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/insmtx/Leros/backend/types"
+)
+
+// nonSeekableReader 模拟 multipart part 等只能顺序读取、无法 Seek 的流。
+type nonSeekableReader struct {
+	data []byte
+	off  int
+}
+
+func (r *nonSeekableReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+func setupUploadStreamTest(t *testing.T) *gorm.DB {
+	t.Helper()
+	initTestStorage(t)
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := database.AutoMigrate(&types.FileUpload{}); err != nil {
+		t.Fatalf("migrate file upload: %v", err)
+	}
+	return database
+}
+
+func TestUploadStream_Success(t *testing.T) {
+	database := setupUploadStreamTest(t)
+	ctx := context.Background()
+
+	data := []byte("hello world, this is a streaming upload payload")
+	reader := &nonSeekableReader{data: data}
+
+	file, err := UploadStream(ctx, database, UploadStreamParams{
+		Filename:     "stream-upload.txt",
+		OriginalName: "original.txt",
+		MimeType:     "text/plain",
+		OrgID:        7,
+		OwnerID:      8,
+		ObjectKey:    "test/7/uploads/stream-upload.txt",
+		Purpose:      PurposeAttachment,
+	}, reader, 1024)
+	if err != nil {
+		t.Fatalf("UploadStream: %v", err)
+	}
+
+	if file.FileSize != int64(len(data)) {
+		t.Errorf("expected file size %d, got %d", len(data), file.FileSize)
+	}
+	sum := sha256.Sum256(data)
+	if file.Sha256 != hex.EncodeToString(sum[:]) {
+		t.Errorf("expected sha256 %x, got %s", sum, file.Sha256)
+	}
+
+	var record types.FileUpload
+	if err := database.First(&record, "public_id = ?", file.PublicID).Error; err != nil {
+		t.Fatalf("file upload record not found: %v", err)
+	}
+
+	reader2, err := OpenFileUpload(ctx, file)
+	if err != nil {
+		t.Fatalf("open uploaded file: %v", err)
+	}
+	defer reader2.Close()
+	got, err := io.ReadAll(reader2)
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("uploaded content mismatch: got %q, want %q", got, data)
+	}
+}
+
+func TestUploadStream_TooLarge(t *testing.T) {
+	database := setupUploadStreamTest(t)
+	ctx := context.Background()
+
+	data := []byte("1234567890")
+	reader := &nonSeekableReader{data: data}
+
+	_, err := UploadStream(ctx, database, UploadStreamParams{
+		Filename:  "too-large.txt",
+		MimeType:  "text/plain",
+		OrgID:     7,
+		OwnerID:   8,
+		ObjectKey: "test/7/uploads/too-large.txt",
+	}, reader, 5)
+	if !errors.Is(err, ErrUploadTooLarge) {
+		t.Fatalf("expected ErrUploadTooLarge, got %v", err)
+	}
+
+	// 超限对象应被清理，不残留孤儿对象。
+	if _, err := GetStorage().GetObject(ctx, DefaultBucket(), "test/7/uploads/too-large.txt"); err == nil {
+		t.Error("oversized object should have been cleaned up")
+	}
+}
+
+func TestUploadStream_Empty(t *testing.T) {
+	database := setupUploadStreamTest(t)
+	ctx := context.Background()
+
+	reader := &nonSeekableReader{data: nil}
+
+	_, err := UploadStream(ctx, database, UploadStreamParams{
+		Filename:  "empty.txt",
+		MimeType:  "text/plain",
+		OrgID:     7,
+		OwnerID:   8,
+		ObjectKey: "test/7/uploads/empty.txt",
+	}, reader, 1024)
+	if !errors.Is(err, ErrEmptyFile) {
+		t.Fatalf("expected ErrEmptyFile, got %v", err)
+	}
+}
+
+func TestUploadStream_CleanupOnDBFailure(t *testing.T) {
+	database := setupUploadStreamTest(t)
+	ctx := context.Background()
+
+	// 删除表使 FileUpload 记录写入必然失败，验证已上传对象会被清理而不残留孤儿。
+	if err := database.Migrator().DropTable(&types.FileUpload{}); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+
+	_, err := UploadStream(ctx, database, UploadStreamParams{
+		Filename:  "db-fail.txt",
+		MimeType:  "text/plain",
+		OrgID:     7,
+		OwnerID:   8,
+		ObjectKey: "test/7/uploads/db-fail.txt",
+	}, &nonSeekableReader{data: []byte("content")}, 1024)
+	if err == nil || !strings.Contains(err.Error(), "create file upload record") {
+		t.Fatalf("expected record create failure, got %v", err)
+	}
+
+	if _, err := GetStorage().GetObject(ctx, DefaultBucket(), "test/7/uploads/db-fail.txt"); err == nil {
+		t.Error("object should have been cleaned up when record creation failed")
+	}
+}
+
+// tinyChunkReader 每次 Read 最多返回 chunk 字节，模拟网络流式分块读取。
+type tinyChunkReader struct {
+	r     io.Reader
+	chunk int
+}
+
+func (r *tinyChunkReader) Read(p []byte) (int, error) {
+	if len(p) > r.chunk {
+		p = p[:r.chunk]
+	}
+	return r.r.Read(p)
+}
+
+func TestUploadStream_MultiChunk(t *testing.T) {
+	database := setupUploadStreamTest(t)
+	ctx := context.Background()
+
+	// 64KB 数据按每次最多 7 字节分块读取，验证跨多次 Read 的计数与 sha256 累计正确。
+	data := bytes.Repeat([]byte("0123456789abcdef"), 4096)
+	reader := &tinyChunkReader{r: &nonSeekableReader{data: data}, chunk: 7}
+
+	file, err := UploadStream(ctx, database, UploadStreamParams{
+		Filename:     "stream-chunked.bin",
+		OriginalName: "original.bin",
+		MimeType:     "application/octet-stream",
+		OrgID:        7,
+		OwnerID:      8,
+		ObjectKey:    "test/7/uploads/stream-chunked.bin",
+		Purpose:      PurposeAttachment,
+	}, reader, 1<<20)
+	if err != nil {
+		t.Fatalf("UploadStream: %v", err)
+	}
+
+	if file.FileSize != int64(len(data)) {
+		t.Errorf("expected file size %d, got %d", len(data), file.FileSize)
+	}
+	sum := sha256.Sum256(data)
+	if file.Sha256 != hex.EncodeToString(sum[:]) {
+		t.Errorf("expected sha256 %x, got %s", sum, file.Sha256)
+	}
+
+	reader2, err := OpenFileUpload(ctx, file)
+	if err != nil {
+		t.Fatalf("open uploaded file: %v", err)
+	}
+	defer reader2.Close()
+	got, err := io.ReadAll(reader2)
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("uploaded content mismatch: got %d bytes, want %d", len(got), len(data))
+	}
+}

--- a/backend/internal/service/file_service.go
+++ b/backend/internal/service/file_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -38,15 +39,9 @@ func (s *fileService) UploadFile(ctx context.Context, req *contract.UploadFileRe
 		return nil, err
 	}
 
-	data, err := io.ReadAll(io.LimitReader(req.File, maxUploadSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("read file: %w", err)
-	}
-	if int64(len(data)) > maxUploadSize {
-		return nil, fmt.Errorf("file size exceeds maximum allowed size of %dMB", maxUploadSize/(1<<20))
-	}
-
-	detectedMime := http.DetectContentType(data[:min(len(data), 512)])
+	bufReader := bufio.NewReaderSize(req.File, 512)
+	head, _ := bufReader.Peek(512)
+	detectedMime := http.DetectContentType(head)
 	mimeType := req.MimeType
 	if mediaType, _, err := mime.ParseMediaType(detectedMime); err == nil {
 		mimeType = mediaType
@@ -64,17 +59,15 @@ func (s *fileService) UploadFile(ctx context.Context, req *contract.UploadFileRe
 		key = fmt.Sprintf("%s/%d/uploads/%s", req.Purpose, caller.OrgID, storeFilename)
 	}
 
-	file, err := filestore.Upload(ctx, s.db, filestore.UploadParams{
-		Data:         data,
+	file, err := filestore.UploadStream(ctx, s.db, filestore.UploadStreamParams{
 		Filename:     storeFilename,
 		OriginalName: req.Filename,
 		MimeType:     mimeType,
-		Size:         int64(len(data)),
 		OrgID:        caller.OrgID,
 		OwnerID:      caller.Uin,
 		ObjectKey:    key,
 		Purpose:      req.Purpose,
-	})
+	}, bufReader, maxUploadSize)
 	if err != nil {
 		return nil, fmt.Errorf("upload file: %w", err)
 	}

--- a/frontend/packages/app-ui/components/skills/SkillImportDialog.tsx
+++ b/frontend/packages/app-ui/components/skills/SkillImportDialog.tsx
@@ -190,8 +190,9 @@ export function SkillImportDialog({ open, onOpenChange, onImportSuccess }: Skill
 		try {
 			// Step 1: Upload file
 			const formData = new FormData();
-			formData.append("file", file);
+			// 后端 /files/upload 为单遍流式解析，file 必须作为最后一个 form part（purpose 等字段须在其之前）。
 			formData.append("purpose", "artifact");
+			formData.append("file", file);
 
 			const uploadResponse = await authenticatedFetch(`${API_BASE_URL}/files/upload`, {
 				method: "POST",

--- a/frontend/packages/store/api/projectFileApi.ts
+++ b/frontend/packages/store/api/projectFileApi.ts
@@ -113,7 +113,8 @@ async function uploadLooseFile({
 	signal,
 }: UploadLooseFileParams): Promise<BackendDataResponse<BackendUploadFilePayload>> {
 	const formData = new FormData();
-	formData.append("file", file);
+	// 后端 /files/upload 为单遍流式解析：purpose/source_id/local-path 等表单字段须位于
+	// file part 之前，file 之后的字段不会被读取，因此 file 必须最后 append。
 	formData.append("purpose", purpose);
 	if (source_id) {
 		formData.append("source_id", source_id);
@@ -121,6 +122,7 @@ async function uploadLooseFile({
 	if (withLocalPath) {
 		formData.append("local-path", resolveComposerUploadFileName(file));
 	}
+	formData.append("file", file);
 
 	const response = await authenticatedFetch(`${API_BASE_URL}/files/upload`, {
 		method: "POST",


### PR DESCRIPTION
## 背景

原文件上传链路将整个请求体与文件整体读入内存（handler 缓冲 multipart、service `io.ReadAll`），大文件场景内存峰值与文件体积一致；超限/空文件等错误也落到 500。

## 改动

- **handler**：改用 `MultipartReader` 单遍流式解析请求体，不再整体缓冲。`purpose`/`source_id`/`local-path` 表单字段须位于 `file` part 之前，`file` 之后字段不生效；前端两个调用方 formData append 顺序已同步调整。
- **校验**：`purpose`/`source_id` 会拼入对象存储 key 路径段，新增字符集（`[A-Za-z0-9_.-]`）、长度与 `..` 校验，非法输入返回明确 400；multipart 字段超长同样返回 400。
- **filestore**：新增 `UploadStream`，经固定缓冲将数据流式写入对象存储并同时累计 sha256，避免整文件进内存；超过 `maxSize` 或空文件时清理已写入对象并返回 `ErrUploadTooLarge`/`ErrEmptyFile`。
- **service**：改为 `bufio.Peek(512)` 探测 MIME（保留 Content-Type 优先），移除整体 `io.ReadAll`。
- **清理**：对象已写入但 DB 记录创建失败时尽力删除对象，避免孤儿对象残留。
- **测试**：新增 `upload_stream_test.go`（成功/超限清理/空文件/DB 失败清理/分块流式读取），handler 侧补充 400 错误映射与非法字段测试。

## 说明

- 已 rebase 同步 `upstream/main`，上传上限沿用上游 `maxUploadSize = 500MB`（#407）。
- 流式解析要求 `file` 为最后一个 multipart part，属 API 行为约定（见 handler 注释与 swagger 描述）。
