### PR TITLE
fix(chat): 追问标题过长时悬浮展示全文

### DIFF
--- a/frontend/packages/app-ui/components/input/QuestionAnswerInput.test.tsx
+++ b/frontend/packages/app-ui/components/input/QuestionAnswerInput.test.tsx
@@ -140,4 +140,34 @@ describe("QuestionAnswerInput", () => {
 
 		expect(handleAnswer).toHaveBeenCalledWith("message-1", "request-1", [["测试架构师"]]);
 	});
+
+	it("问题标题过长时悬浮展示全文", async () => {
+		const user = userEvent.setup();
+		const longQuestion =
+			"请确认本次要比对的招标文件版本、投标文件范围，以及是否需要把报价明细、技术偏离表和商务条款一起纳入评审结论？";
+
+		render(
+			<QuestionAnswerInput
+				question={makeQuestion({
+					questions: [
+						{
+							question: longQuestion,
+							options: [{ label: "全部纳入" }, { label: "仅技术偏离表" }],
+							multiple: false,
+							custom: false,
+						},
+					],
+				})}
+				messageId="message-1"
+				variant="default"
+				onAnswer={vi.fn()}
+			/>,
+		);
+
+		await user.hover(screen.getByText(longQuestion, { selector: '[data-slot="tooltip-trigger"]' }));
+
+		expect(
+			await screen.findByText(longQuestion, { selector: '[data-slot="tooltip-content"]' }),
+		).toBeInTheDocument();
+	});
 });

--- a/frontend/packages/app-ui/components/input/QuestionAnswerInput.tsx
+++ b/frontend/packages/app-ui/components/input/QuestionAnswerInput.tsx
@@ -4,6 +4,7 @@ import type { QuestionRequest } from "@leros/store/types/chat";
 import { Badge } from "@leros/ui/components/ui/badge";
 import { Button } from "@leros/ui/components/ui/button";
 import { Input } from "@leros/ui/components/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@leros/ui/components/ui/tooltip";
 import { cn } from "@leros/ui/lib/utils";
 import { AlertCircle, ChevronLeft, ChevronRight, Info, LoaderCircle } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -393,8 +394,22 @@ export function QuestionAnswerInput({
 					{/* Header */}
 					<div className="flex items-start justify-between gap-3 px-3.5 pb-2 pt-2.5 sm:px-4">
 						<div className="flex min-w-0 items-center gap-2">
-							<h3 className="truncate text-[15px] font-semibold leading-5 text-slate-950">
-								{currentQuestion.question}
+							<h3 className="min-w-0 text-[15px] font-semibold leading-5 text-slate-950">
+								<Tooltip>
+									{/* 中文注释：标题单行截断，用 span 承接悬浮，避免 TooltipTrigger 默认 button 嵌套进标题。 */}
+									<TooltipTrigger
+										render={<span className="block min-w-0 cursor-default truncate" />}
+									>
+										{currentQuestion.question}
+									</TooltipTrigger>
+									<TooltipContent
+										side="top"
+										align="start"
+										className="max-w-sm whitespace-normal break-words text-left leading-5"
+									>
+										{currentQuestion.question}
+									</TooltipContent>
+								</Tooltip>
 							</h3>
 							<div className="shrink-0">
 								<QuestionStatusBadge question={question} />


### PR DESCRIPTION
- question_ask 标题单行截断后无法看完，悬停用 tooltip 展示完整问题
- 标题仍用 h3 承载文案，避免空标题触发无障碍检查
- 补充长标题悬停展示全文的单测