### PR TITLE
fix(project): 修复问答新建项目不出现在侧栏最近列表

### DIFF
--- a/frontend/packages/app-ui/components/layout/LeftRail.test.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.test.tsx
@@ -52,6 +52,10 @@ vi.mock("@leros/store", () => ({
 		hasMore: false,
 	}),
 	mergeProjectsFromListResult: (items: unknown[]) => items,
+	upsertProjectsIntoCache: (incoming: Array<{ id: string }>, local: Array<{ id: string }>) => {
+		const incomingIds = new Set(incoming.map((project) => project.id));
+		return [...incoming, ...local.filter((project) => !incomingIds.has(project.id))];
+	},
 	appendProjectsFromListResult: (incoming: unknown[], local: unknown[]) => [...local, ...incoming],
 	projectFileApi: {},
 	useProjectMenuCapabilities: () => ({ loading: false, hasAny: false }),

--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -203,7 +203,10 @@ export function LeftRail({
 	const { isHydrated, isAuthenticated, openAuthDialog, requireAuth, logout, user } = useAuth();
 	// 中文注释：OSS 版无多组织切换，隐藏左下角用户菜单中的「切换组织」入口。
 	const canSwitchOrganization = edition !== "oss";
-	const projectList = usePaginatedProjectList({ enabled: isAuthenticated });
+	const projectList = usePaginatedProjectList({
+		enabled: isAuthenticated,
+		includeCachedProjects: true,
+	});
 	const visibleProjects = isAuthenticated ? projectList.projects : [];
 	useProjectsMenuCapabilities(visibleProjects.map((project) => project.id));
 	const [renameProject, setRenameProject] = useState<Project | null>(null);

--- a/frontend/packages/app-ui/components/layout/left-rail-list-utils.test.ts
+++ b/frontend/packages/app-ui/components/layout/left-rail-list-utils.test.ts
@@ -60,4 +60,18 @@ describe("getRecentProjectsForLeftRail", () => {
 			"project-6",
 		]);
 	});
+
+	it("会把后插入但更新时间最新的项目排到最前", () => {
+		const projects = [
+			{ id: "project-old", updatedAt: 100 },
+			{ id: "project-from-qa", updatedAt: 200 },
+		];
+
+		const visibleProjects = getRecentProjectsForLeftRail(projects);
+
+		expect(visibleProjects.map((project) => project.id)).toEqual([
+			"project-from-qa",
+			"project-old",
+		]);
+	});
 });

--- a/frontend/packages/app-ui/components/layout/left-rail-list-utils.ts
+++ b/frontend/packages/app-ui/components/layout/left-rail-list-utils.ts
@@ -1,7 +1,7 @@
 export const LEFT_RAIL_LIST_PREVIEW_LIMIT = 6;
 
 export function getRecentProjectsForLeftRail<T extends { updatedAt: number }>(projects: T[]) {
-	// 中文注释：最近项目按更新时间倒序展示当前已加载分页，后续页由滚动懒加载补齐。
+	// 中文注释：最近项目按更新时间倒序；含问答刚写入缓存、尚未出现在当前分页的项目。
 	return [...projects].sort((a, b) => b.updatedAt - a.updatedAt);
 }
 

--- a/frontend/packages/app-ui/components/project/usePaginatedProjectList.ts
+++ b/frontend/packages/app-ui/components/project/usePaginatedProjectList.ts
@@ -6,6 +6,7 @@ import {
 	mergeProjectsFromListResult,
 	PROJECT_LIST_PAGE_SIZE,
 	type Project,
+	upsertProjectsIntoCache,
 	useLayoutStore,
 } from "@leros/store";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -15,8 +16,16 @@ export function usePaginatedProjectList(options: {
 	keyword?: string;
 	debounceMs?: number;
 	pageSize?: number;
+	/** 把缓存里尚未出现在当前分页的项目一并展示（侧栏最近项目需要，搜索/选择器不能开）。 */
+	includeCachedProjects?: boolean;
 }) {
-	const { enabled, keyword = "", debounceMs = 300, pageSize = PROJECT_LIST_PAGE_SIZE } = options;
+	const {
+		enabled,
+		keyword = "",
+		debounceMs = 300,
+		pageSize = PROJECT_LIST_PAGE_SIZE,
+		includeCachedProjects = false,
+	} = options;
 	const upsertProjects = useLayoutStore((state) => state.upsertProjects);
 	const mutationEpoch = useLayoutStore((state) => state.projectsMutationEpoch);
 	const projectCache = useLayoutStore((state) => state.projects);
@@ -116,8 +125,11 @@ export function usePaginatedProjectList(options: {
 	]);
 
 	const projects = useMemo(
-		() => mergeProjectsFromListResult(items, projectCache),
-		[items, projectCache],
+		() =>
+			includeCachedProjects
+				? upsertProjectsIntoCache(items, projectCache)
+				: mergeProjectsFromListResult(items, projectCache),
+		[includeCachedProjects, items, projectCache],
 	);
 
 	return {

--- a/frontend/packages/store/slices/layoutSlice.test.ts
+++ b/frontend/packages/store/slices/layoutSlice.test.ts
@@ -312,6 +312,22 @@ describe("upsertProjectsIntoCache", () => {
 		expect(cached[0]?.name).toBe("新名称");
 		expect(cached[0]?.tasks.map((task) => task.id)).toEqual(["task-1"]);
 	});
+
+	it("合并当前分页时不会丢掉问答刚写入缓存的新项目", () => {
+		const pageItems = [createProject({ id: "project-1", name: "旧项目", updatedAt: 10 })];
+		const cache = [
+			createProject({ id: "project-from-qa", name: "新问答", updatedAt: 20 }),
+			...pageItems,
+		];
+
+		expect(mergeProjectsFromListResult(pageItems, cache).map((project) => project.id)).toEqual([
+			"project-1",
+		]);
+		expect(upsertProjectsIntoCache(pageItems, cache).map((project) => project.id)).toEqual([
+			"project-1",
+			"project-from-qa",
+		]);
+	});
 });
 
 describe("LayoutActionImpl.fetchProjects", () => {


### PR DESCRIPTION
- 分页改造后侧栏只渲染当前页，问答写入的全局缓存项目被丢掉
- 最近项目改为合并缓存中尚未出现在当前页的项目，并按更新时间倒序置顶
- 搜索/选择器仍只用接口分页，避免把不匹配的缓存项掺进去