### PR TITLE
fix(project): 账户改名后右侧项目队友同步显示当前名称

### DIFF
--- a/frontend/packages/app-ui/components/layout/ProjectPage.tsx
+++ b/frontend/packages/app-ui/components/layout/ProjectPage.tsx
@@ -79,6 +79,7 @@ import {
 	projectMemberListClassName,
 	sortProjectMembers,
 } from "../project-members/ProjectMemberPickerDialog";
+import { applyCurrentUserProfileToProjectMembers } from "../project-members/project-member-profile";
 import { canQuickRemoveProjectMember } from "../project-members/project-member-removal";
 import { openProjectFilePreview } from "./file-preview-store";
 import { PROJECT_FILE_VERSION_CHANGED_EVENT } from "./file-preview-utils";
@@ -690,25 +691,28 @@ function ProjectConfigSidebar({
 	}, [mcpOptions, mcpSearch, selectedMCPIDs]);
 	const projectMembersWithLatestAssistantAvatar = useMemo(
 		() =>
-			project.members.map((member) => {
-				if (member.type !== "assistant") return member;
-				const matchedAssistant = assistants.find(
-					(assistant) =>
-						(member.publicId && assistant.publicId === member.publicId) ||
-						(member.memberId > 0 && assistant.id === member.memberId),
-				);
-				if (!matchedAssistant) return member;
+			applyCurrentUserProfileToProjectMembers(
+				project.members.map((member) => {
+					if (member.type !== "assistant") return member;
+					const matchedAssistant = assistants.find(
+						(assistant) =>
+							(member.publicId && assistant.publicId === member.publicId) ||
+							(member.memberId > 0 && assistant.id === member.memberId),
+					);
+					if (!matchedAssistant) return member;
 
-				return {
-					...member,
-					name: member.name || matchedAssistant.name,
-					roleName: matchedAssistant.roleName,
-					description: member.description || matchedAssistant.description,
-					// 中文注释：项目详情里的成员头像可能是旧快照，优先用最新 AI 队友头像 public_id。
-					avatarUrl: matchedAssistant.avatar || member.avatarUrl,
-				};
-			}),
-		[assistants, project.members],
+					return {
+						...member,
+						name: member.name || matchedAssistant.name,
+						roleName: matchedAssistant.roleName,
+						description: member.description || matchedAssistant.description,
+						// 中文注释：项目详情里的成员头像可能是旧快照，优先用最新 AI 队友头像 public_id。
+						avatarUrl: matchedAssistant.avatar || member.avatarUrl,
+					};
+				}),
+				user,
+			),
+		[assistants, project.members, user],
 	);
 
 	const saveDescription = async () => {

--- a/frontend/packages/app-ui/components/project-members/project-member-profile.test.ts
+++ b/frontend/packages/app-ui/components/project-members/project-member-profile.test.ts
@@ -1,0 +1,71 @@
+import type { ProjectMember } from "@leros/store";
+import { describe, expect, it } from "vitest";
+
+import { applyCurrentUserProfileToProjectMembers } from "./project-member-profile";
+
+function createMember(overrides: Partial<ProjectMember> = {}): ProjectMember {
+	return {
+		id: "user-owner",
+		memberId: 17,
+		publicId: "user-1",
+		type: "user",
+		role: "owner",
+		name: "旧名称",
+		avatarUrl: "old-avatar",
+		...overrides,
+	};
+}
+
+describe("applyCurrentUserProfileToProjectMembers", () => {
+	it("按 publicId 把当前登录用户的最新名称同步到项目队友列表", () => {
+		const members = [
+			createMember(),
+			createMember({
+				id: "user-other",
+				memberId: 18,
+				publicId: "user-2",
+				name: "同事",
+			}),
+		];
+
+		expect(
+			applyCurrentUserProfileToProjectMembers(members, {
+				publicId: "user-1",
+				uin: 17,
+				name: "新名称",
+				uinName: "新名称",
+			}).map((member) => member.name),
+		).toEqual(["新名称", "同事"]);
+	});
+
+	it("publicId 缺失时按 uin 识别本人并更新名称", () => {
+		const members = [createMember({ publicId: undefined })];
+
+		expect(
+			applyCurrentUserProfileToProjectMembers(members, {
+				uin: 17,
+				name: "新名称",
+			})[0]?.name,
+		).toBe("新名称");
+	});
+
+	it("不改写其他队友或 AI 队友的名称", () => {
+		const members = [
+			createMember({
+				id: "assistant-1",
+				memberId: 9,
+				publicId: "assistant-1",
+				type: "assistant",
+				name: "策略师",
+			}),
+		];
+
+		expect(
+			applyCurrentUserProfileToProjectMembers(members, {
+				publicId: "user-1",
+				uin: 17,
+				name: "新名称",
+			})[0]?.name,
+		).toBe("策略师");
+	});
+});

--- a/frontend/packages/app-ui/components/project-members/project-member-profile.ts
+++ b/frontend/packages/app-ui/components/project-members/project-member-profile.ts
@@ -1,0 +1,42 @@
+import type { ProjectMember } from "@leros/store";
+
+export type CurrentUserProjectProfile = {
+	publicId?: string;
+	uin?: number;
+	userId?: number;
+	name?: string;
+	uinName?: string;
+	avatarUrl?: string;
+};
+
+function isSameCurrentUserMember(
+	member: ProjectMember,
+	currentUser: CurrentUserProjectProfile,
+): boolean {
+	if (member.type !== "user") return false;
+	const publicId = currentUser.publicId?.trim();
+	if (publicId && member.publicId === publicId) return true;
+	// 中文注释：真人成员的 memberId 存的是 uin，登录态 publicId 未补齐时用它识别本人。
+	if (currentUser.uin && currentUser.uin !== 0 && member.memberId === currentUser.uin) return true;
+	return false;
+}
+
+/** 用当前登录用户的最新资料覆盖项目队友快照里的本人名称/头像。 */
+export function applyCurrentUserProfileToProjectMembers(
+	members: ProjectMember[],
+	currentUser: CurrentUserProjectProfile | null | undefined,
+): ProjectMember[] {
+	if (!currentUser) return members;
+	const nextName = currentUser.uinName?.trim() || currentUser.name?.trim();
+	const nextAvatarUrl = currentUser.avatarUrl?.trim();
+	if (!nextName && !nextAvatarUrl) return members;
+
+	return members.map((member) => {
+		if (!isSameCurrentUserMember(member, currentUser)) return member;
+		return {
+			...member,
+			name: nextName || member.name,
+			avatarUrl: nextAvatarUrl || member.avatarUrl,
+		};
+	});
+}


### PR DESCRIPTION
- 项目队友名单是进页快照，账户改名只更新登录态，右侧本人名称不会跟着变
- 展示时按 publicId/uin 把当前用户最新名称和头像叠到对应成员上
- 其他队友和 AI 队友不受影响