### PR TITLE
style(avatar): 去掉账户管理与侧栏头像的紫色描边

### DIFF
--- a/frontend/packages/app-ui/components/layout/LeftRail.tsx
+++ b/frontend/packages/app-ui/components/layout/LeftRail.tsx
@@ -1388,7 +1388,8 @@ function AccountManagementDialog({
 					<div className="relative">
 						<button
 							type="button"
-							className="group relative size-24 overflow-hidden rounded-full bg-[var(--leros-primary)] text-white ring-4 ring-slate-100"
+							className="leros-avatar group relative overflow-hidden bg-transparent text-[11px] font-semibold"
+							style={{ background: "transparent", width: 96, height: 96 }}
 							onClick={() => fileInputRef.current?.click()}
 							disabled={uploadingAvatar}
 							aria-label="上传头像"
@@ -1404,10 +1405,12 @@ function AccountManagementDialog({
 											seed={`user:${displayPhone || user.name}`}
 											alt={user.name ?? "Avatar"}
 											className="h-full w-full"
-											size={128}
+											size={96}
 										/>
 									) : (
-										<span className="text-xl font-semibold">{getAvatarInitial("Lework")}</span>
+										<span className="text-xl font-semibold">
+											{getAvatarInitial("Lework")}
+										</span>
 									)
 								}
 							/>
@@ -1510,8 +1513,8 @@ function ProfileAvatar({ user }: { user: AuthUser | null }) {
 
 	return (
 		<span
-			className="leros-avatar overflow-hidden text-[11px] font-semibold"
-			style={{ background: "var(--leros-primary)", color: "#fff" }}
+			className="leros-avatar overflow-hidden bg-transparent text-[11px] font-semibold"
+			style={{ background: "transparent" }}
 		>
 			<ProtectedImage
 				src={user?.avatarUrl}


### PR DESCRIPTION
- 头像容器品牌紫底会从圆形裁切缝里渗出，看起来像一圈紫边
- 账户管理与左下角头像都去掉这层底色，只保留 leros-avatar 浅色细边
- 账户管理大头像与侧栏同一套样式，仅尺寸更大